### PR TITLE
Usage of example.org

### DIFF
--- a/admin.md
+++ b/admin.md
@@ -6,7 +6,7 @@ Yunohost has an administrator web interface. The other way to administer your Yu
 
 ### Access
 
-You can access your administrator web interface at this address: https://your-domain.org/yunohost/admin (replace 'your-domain.org' with your own domain name)
+You can access your administrator web interface at this address: https://example.org/yunohost/admin (replace 'your-domain.org' with your own domain name)
 
 <div class="text-center" style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
 <img src="https://yunohost.org/images/manage_en.png" style="max-width:100%;">


### PR DESCRIPTION
example.org and example.com must be used in documentation : other domain can go to uncontrolled and uneeded information. Alternaive is to use localhost.localdomain or yunohost.or.
