### PR TITLE
Usage of example.org for example web lin

### DIFF
--- a/admin.md
+++ b/admin.md
@@ -6,7 +6,7 @@ Yunohost has an administrator web interface. The other way to administer your Yu
 
 ### Access
 
-You can access your administrator web interface at this address: https://your-domain.org/yunohost/admin (replace 'your-domain.org' with your own domain name)
+You can access your administrator web interface at this address: https://example.org/yunohost/admin (replace 'example.org' with your own domain name)
 
 <div class="text-center" style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
 <img src="https://yunohost.org/images/manage_en.png" style="max-width:100%;">

--- a/admin_fr.md
+++ b/admin_fr.md
@@ -6,7 +6,7 @@ YunoHost est fourni avec une interface web d’administration. L’autre interfa
 
 ### Accès
 
-L'interface admin est accessible depuis votre instance YunoHost à l'adresse https://votre-domaine.org/yunohost/admin (remplacez votre-domaine.org par la bonne valeur)
+L'interface admin est accessible depuis votre instance YunoHost à l'adresse https://example.org/yunohost/admin (remplacez example.org par la bonne valeur)
 
 <div class="text-center" style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
 <img src="https://yunohost.org/images/manage.png" style="max-width:100%;">

--- a/app_radicale.md
+++ b/app_radicale.md
@@ -1,14 +1,14 @@
 #Radicale
 
 ## CalDAV Sync
-URL: https://domaine.fr/patch/login/calendar.ics/
+URL: https://example.org/patch/login/calendar.ics/
 
-Exemple: https://plop.nohost.me/sync/beudbeud/calendar.ics/
+Exemple: https://plop.example.org/sync/beudbeud/calendar.ics/
 
 ## CardDAV Sync
-URL: https://domaine.fr/patch/login/AddressBook.vcf/
+URL: https://example.org/patch/login/AddressBook.vcf/
 
-Exemple: https://plop.nohost.me/sync/beudbeud/AddressBook.vcf/
+Exemple: https://plop.example.org/sync/beudbeud/AddressBook.vcf/
 
 ##Davdroid
 https://github.com/abeudin/radicale_ynh/pull/4

--- a/app_radicale_fr.md
+++ b/app_radicale_fr.md
@@ -1,13 +1,13 @@
 #Radicale
 ## CalDAV Sync
-URL : https://domaine.fr/patch/login/calendar.ics/
+URL : https://example.org/patch/login/calendar.ics/
 
-Exemple : https://plop.nohost.me/sync/beudbeud/calendar.ics/
+Exemple : https://plop.example.org/sync/beudbeud/calendar.ics/
 
 ## CardDAV Sync
-URL : https://domaine.fr/patch/login/AddressBook.vcf/
+URL : https://example.org/patch/login/AddressBook.vcf/
 
-Exemple : https://plop.nohost.me/sync/beudbeud/AddressBook.vcf/
+Exemple : https://plop.example.org/sync/beudbeud/AddressBook.vcf/
 
 ##Davdroid
 https://github.com/abeudin/radicale_ynh/pull/4


### PR DESCRIPTION
- Actually website is OK, but maybe in next year it's a 'very bad name to use'
- Not sure for the calendar example : maybe take demo.yunohost.org for the example (but actually can test link : install of CallDav is broken)
- Maybe use demo.yunohost.org is a better idea for all example link ?
