### PR TITLE
Add Let's Chat to work-in-progress apps

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -133,6 +133,7 @@ The packagers will appreciate your remarks. If you test them and find issues, or
 | [KiwiIRC](http://kiwiirc.com) | ju | <div class="ready"/> | https://github.com/julienmalik/kiwiirc_ynh | Web IRC client |
 | [Laverna](https://laverna.cc/) | anaqreon | <div class="inprogress"/> | https://github.com/anaqreon/laverna_ynh | Note taking app |
 | [Leed](http://projet.idleman.fr/leed/) | Maniack Crudelis | <div class="ready"/> | https://github.com/maniackcrudelis/leed_ynh | RSS reader |
+| [Let's Chat](http://sdelements.github.io/lets-chat/) | Pierre de La Morinerie | <div class="ready"/> | https://github.com/kemenaran/yunohost-lets-chat | Chat for small teams |
 | [LimeSurvey](http://www.limesurvey.org/en/) | zamentur | <div class="inprogress"/> | https://github.com/zamentur/limesurvey_ynh | Web survey tool |
 | [Linux Dash](http://linuxdash.afaqtariq.com/) | opi | <div class="ready"/> | https://github.com/opi/linuxdash_ynh | Monitoring web dashboard |
 | [Lychee](http://lychee.electerious.com/) | titoko | <div class="inprogress"/> | https://github.com/titoko/lychee_ynh | Web photo-management |


### PR DESCRIPTION
[Let's Chat](http://sdelements.github.io/lets-chat/) is a small self-hosted chat (that looks a bit like Slack).