### PR TITLE
Add ip4 and ip6 in SPF

### DIFF
--- a/dkim_fr.md
+++ b/dkim_fr.md
@@ -158,7 +158,8 @@ Pour tester que tout fonctionne bien (n'oubliez pas que la propagation DNS peut 
 # SPF
 Enfin, n'oubliez pas d'ajouter une clé SPF dans votre [zone DNS](/dns_config_fr) (ou un champ TXT si SPF n'est pas disponible) :
 ```bash
-DOMAIN.TLD 1800 TXT "v=spf1 a:DOMAIN.TLD mx ?all"
+DOMAIN.TLD 1800 TXT "v=spf1 a:DOMAIN.TLD ip4:<IPv4 publique du serveur> ip6:<IPv6 publique du serveur> mx ?all"
 ```
 
 Pour rappel, le champ SPF indique que seule la machine utilisant l'adresse IP indiquée dans votre zone DNS est autorisée à envoyer des courriels.
+Si vous n'avez pas d'IPv6 sur votre serveur, supprimez simplement toute la section ip6:<..>


### PR DESCRIPTION
Ajout de ip4 et ip6 dans le champ SPF
Commentaire indiquant que la section ip6 n'est pas obligatoire et peut être enlevée