### PR TITLE
add wildcard in dns config example

### DIFF
--- a/dns_config.md
+++ b/dns_config.md
@@ -5,7 +5,9 @@ Sample DNS config for domain.tld
 ```bash
 #### IPv4 & IPv6
 @ 900 IN A 111.222.333.444 (Minimal)
+* 900 IN A 111.222.333.444 (wildcard)
 @ 900 IN AAAA 2001:AABB:CCDD:EEFF:1122:3344:5566:7788
+* 900 IN AAAA 2001:AABB:CCDD:EEFF:1122:3344:5566:7788
 
 #### Handle www subdomain
 www 1800 IN CNAME @


### PR DESCRIPTION
Ohai,

Currently YUNOHOST doesn't recommand to add a wildcard to the domain name which is a bit sad since it doesn't cost anything and allow more option to the user. Here is a patch to fix this.

Additionnal coment: apparently 900 for a TTL value is way to low and should be more something like 21600 according to PEB on #ffdn

Cheers :heart: 
