### PR TITLE
Adding Debian 8 in prerequisite in addition to Debian 7

### DIFF
--- a/install_on_debian.md
+++ b/install_on_debian.md
@@ -8,7 +8,7 @@
 
 An ARM box, a VPS, a dedicated server, a standard x86 computer, an old Macintosh, ...
 
-* with **Debian 7** (Wheezy, Raspbian, Cubian, etc.) installed
+* with **Debian 7** (Wheezy, Raspbian, Cubian, etc.) or **Debian 8** (Jessie) installed
 * connected to the Internet
 * with a **root access** directly or via SSH
 

--- a/install_on_debian_fr.md
+++ b/install_on_debian_fr.md
@@ -8,7 +8,7 @@
 
 Sur une plateforme ARM, un VPS, un serveur dédié, un ordinateur x86 standard, un vieux Macintosh, ...
 
-* avec **Debian 7** (Wheezy, Raspbian, Cubian, etc…) d’installé
+* avec **Debian 7** (Wheezy, Raspbian, Cubian, etc…) ou **Debian 8** (Jessie) d’installé
 * connecté à Internet avec un câble RJ-45
 * avec un **accès root** directement ou par SSH
 

--- a/install_on_dedicated_server.md
+++ b/install_on_dedicated_server.md
@@ -7,7 +7,7 @@
 <img src="https://yunohost.org/images/vps.png" width=250>
 
 * A dedicated server **OR** a VPS with at least **256MB** RAM
-* A **Debian 7** OS up and running on it
+* A **Debian 7** or **Debian 8** OS up and running on it
 
 ---
 

--- a/install_on_dedicated_server_fr.md
+++ b/install_on_dedicated_server_fr.md
@@ -7,7 +7,7 @@
 <img src="https://yunohost.org/images/vps.png" width=250>
 
 * Un serveur dédié **OU** un VPS avec au moins **256MB** de RAM
-* Une installation **Debian 7** fonctionnelle
+* Une installation **Debian 7** ou **Debian 8** fonctionnelle
 
 ---
 


### PR DESCRIPTION
Yunohost works on Debian 7 and Debian 8. Adding Debian 8 on pre requisite