### PR TITLE
[enh] split apps list in 3 lists with clearer informations

### DIFF
--- a/apps_in_progress_fr.md
+++ b/apps_in_progress_fr.md
@@ -28,7 +28,20 @@ N’hésitez pas à vous créer un compte GitHub pour faire part de vos remarque
 <div class="btn btn-default btn-xs pull-right" data-toggle="collapse" data-target="#app-accordion2 .collapse">Tout déplier</div>
 </div>
 
-<div class="panel-group" id="app-accordion2"></div>
+<h2>Applications dites fonctionnelles</h2>
+<p><b>Remarque : c'est le mainteneur de l'application qui la décrit comme fonctionnelle, pas l'équipe de YunoHost. Installez la à vos risques et péril. Nous ne fournirrons pas de support dessus.</b></p>
+
+<div class="panel-group" id="app-accordion2-working"></div>
+
+<h2>Applications en cours de développement</h2>
+<p>Il s'agit d'application <b>pas encore fonctionnelles</b> mais en cours de développement, nous vous <b>déconseillons fortement de les installer</b> sauf si vous savez ce que vous faites.</p>
+
+<div class="panel-group" id="app-accordion2-inprogress"></div>
+
+<h2>Applications cassées</h2>
+<p>Ne les installez <b>PAS</b>, elles sont là pour référence le temps d'être réparées.</p>
+
+<div class="panel-group" id="app-accordion2-notworking"></div>
 
 <script type="text/template" id="app-template2">
   <div class="panel panel-default">
@@ -101,7 +114,7 @@ $(document).ready(function () {
           .replace('{app_mail}', infos.manifest.maintainer.email);
       }
 
-      $('#app-accordion2').append(html);
+      $('#app-accordion2-' + infos.state).append(html);
       $('.app_'+ app_id).attr('id', 'app_'+ app_id);
 
       setTimeout(function() {


### PR DESCRIPTION
Salut,

J'ai eu l'idée de spliter la liste des applications par états, histoire que ça soit bien plus facile et clair pour les utilisateurs de voir dans quel état sont les applications et celles qui sont censé marché. J'en ai profité pour rajouter du texte informatif sur l'état des applications et ceux à quoi on s'engageait.

Je n'ai pas encore fait ça avec la liste des apps anglaises (qui a l'air d'être plutôt désynchos avec la page fr).

Voici un screenshot:
![capture d ecran 2016-04-17 a 06 19 18](https://cloud.githubusercontent.com/assets/41827/14585062/fa0dfca4-0465-11e6-80aa-a0652dd8d7a3.png)

(remarque: certaines icones sont cassés car elles ne sont pas présentent dans le git).