### PR TITLE
[fix] packaging: comply with 2.4 multi-instance

### DIFF
--- a/packaging_apps_multiinstance.md
+++ b/packaging_apps_multiinstance.md
@@ -4,13 +4,13 @@
 Multi-instance is application capacity to be installed several times.
 
 #### Scripts
-When YunoHost installs the application a second time, it gives to the script, at last argument, `${id}__2` with the application `${id}` coming from the manifest. The value `n` in `${id}__n` is incremented each time a new instance of the application is installed.
+When YunoHost installs the application, it passes `$YNH_APP_INSTANCE_NAME` var to the script, set to value `id__n` with the application `id` coming from the manifest and `n` being an integer  incremented each time a new instance of the application is installed.
 
 **E.g.** in the roundcube script, database is called `roundcube`, the install directory `roundcube` and the [Nginx configuration](packaging_apps_nginx_conf_en) `roundcube`. This way, the second instance of roundcube will not conflict with the first one, and will be installed in the `roundcube__2` database, in the `roundcube__2`directory, and with the `roundcube__2` Nginx configuration.
 
-Retrieve last variable given to scripts:
+Retrieve app identifier (including the multi-instance id):
 ```bash
-APP=${!#}
+app=$YNH_APP_INSTANCE_NAME
 ```
 
 #### Manifest

--- a/packaging_apps_multiinstance_fr.md
+++ b/packaging_apps_multiinstance_fr.md
@@ -4,14 +4,14 @@
 Le multi-instance est la capacité d’une application à être installée plusieurs fois.
 
 #### Scripts
-Lorsque YunoHost installe une seconde fois l’application, il passe au script en dernier paramètre `id__2` avec l’identifiant de l’application `id` provenant du manifeste. La valeur `n` dans `id__n` est incrémentée à chaque nouvelle instance de l’application.
+Lorsque YunoHost installe l’application, il passe au script dans la variable `$YNH_APP_INSTANCE_NAME`  la valeur `id__n` avec l’identifiant de l’application `id` provenant du manifeste et `n` un nombre incrémentée à chaque nouvelle instance de l’application.
 
-**Par exemple** : dans le script roundcube, il faut nommer la base de données `roundcube`, le dossier d’installation `roundcube` et la [configuration Nginx](packaging_apps_nginx_conf_fr) `roundcube`. De cette manière, la seconde installation de roundcube ne rentrera pas en conflit avec la première, et sera installée dans la base de données `roundcube__2`, dans le répertoire `roundcube__2`, et avec la configuration Nginx `roundcube__2`.
+**Par exemple** : dans le script roundcube, il faut nommer la base de données `roundcube`, le dossier d’installation `roundcube` et la [configuration Nginx](packaging_apps_nginx_conf_fr) `roundcube`. De cette manière, la seconde installation de roundcube ne rentrera pas en conflit avec la première, et sera installée dans la base de données `roundcube__2`, dans le répertoire `roundcube__2`, et avec la configuration Nginx `roundcube__2`.
 
 
-Récupération de la dernière variable passée aux scripts :
+Récupération de l'identifiant de l'app (incluant l'id multi-instance) :
 ```bash
-APP=${!#}
+app=$YNH_APP_INSTANCE_NAME
 ```
 
 #### Manifeste


### PR DESCRIPTION
No longer using last-argument in favor of $YNH_APP_INSTANCE_NAME.