### PR TITLE
Pentest documentation

### DIFF
--- a/security.md
+++ b/security.md
@@ -118,6 +118,6 @@ sudo service yunohost-api stop
 
 Some [pentests](https://en.wikipedia.org/wiki/Penetration_test) have been done on a YunoHost 2.4 instance (french):
 
-- [#1 – Preparation](https://blog.exadot.fr/2016/07/03/pentest-dune-instance-yunohost-1-preparation)
-- [#2 – The functionning](https://blog.exadot.fr/2016/07/12/pentest-dune-instance-yunohost-2-le-fonctionnement)
-- [#3 – Black Box Audit](https://blog.exadot.fr/2016/08/26/pentest-dune-instance-yunohost-3-audit-en-black-box)
+- [1) Preparation](https://blog.exadot.fr/2016/07/03/pentest-dune-instance-yunohost-1-preparation)
+- [2) The functionning](https://blog.exadot.fr/2016/07/12/pentest-dune-instance-yunohost-2-le-fonctionnement)
+- [3) Black Box Audit](https://blog.exadot.fr/2016/08/26/pentest-dune-instance-yunohost-3-audit-en-black-box)

--- a/security.md
+++ b/security.md
@@ -113,3 +113,11 @@ YunoHost administration is accessible through an **HTTP API**, served on the 678
 ```bash
 sudo service yunohost-api stop
 ```
+
+### YunoHost penetration test
+
+Some [pentests](https://en.wikipedia.org/wiki/Penetration_test) have been done on a YunoHost 2.4 instance (french):
+
+- [#1 – Preparation](https://blog.exadot.fr/2016/07/03/pentest-dune-instance-yunohost-1-preparation)
+- [#2 – The functionning](https://blog.exadot.fr/2016/07/12/pentest-dune-instance-yunohost-2-le-fonctionnement)
+- [#3 – Black Box Audit](https://blog.exadot.fr/2016/08/26/pentest-dune-instance-yunohost-3-audit-en-black-box)

--- a/security_fr.md
+++ b/security_fr.md
@@ -126,6 +126,6 @@ sudo service yunohost-api stop
 
 Des [pentests](https://fr.wikipedia.org/wiki/pentest) ont été effectués sur une instance de YunoHost 2.4 :
 
-- [#1 – Préparation](https://blog.exadot.fr/2016/07/03/pentest-dune-instance-yunohost-1-preparation)
-- [#2 – Le fonctionnement](https://blog.exadot.fr/2016/07/12/pentest-dune-instance-yunohost-2-le-fonctionnement)
-- [#3 – Audit en Black Box](https://blog.exadot.fr/2016/08/26/pentest-dune-instance-yunohost-3-audit-en-black-box)
+- [1) Préparation](https://blog.exadot.fr/2016/07/03/pentest-dune-instance-yunohost-1-preparation)
+- [2) Le fonctionnement](https://blog.exadot.fr/2016/07/12/pentest-dune-instance-yunohost-2-le-fonctionnement)
+- [3) Audit en Black Box](https://blog.exadot.fr/2016/08/26/pentest-dune-instance-yunohost-3-audit-en-black-box)

--- a/security_fr.md
+++ b/security_fr.md
@@ -121,3 +121,11 @@ YunoHost est administrable via une **API HTTP**, servie sur le port 6787 par dé
 ```bash
 sudo service yunohost-api stop
 ```
+
+### Tests d’intrusion de YunoHost
+
+Des [pentests](https://fr.wikipedia.org/wiki/pentest) ont été effectués sur une instance de YunoHost 2.4 :
+
+- [#1 – Préparation](https://blog.exadot.fr/2016/07/03/pentest-dune-instance-yunohost-1-preparation)
+- [#2 – Le fonctionnement](https://blog.exadot.fr/2016/07/12/pentest-dune-instance-yunohost-2-le-fonctionnement)
+- [#3 – Audit en Black Box](https://blog.exadot.fr/2016/08/26/pentest-dune-instance-yunohost-3-audit-en-black-box)


### PR DESCRIPTION
I added pentest links in security part of documentation.

That could show how secure is YunoHost and what have been done on it.

Are you ok to publicly display it?