### PR TITLE
Add link to issue proposing to migrate Shout package to The Lounge

### DIFF
--- a/apps_wishlist.md
+++ b/apps_wishlist.md
@@ -71,7 +71,7 @@ The following list is a compiled wishlist of applications that would be nice-to-
 - [KrISS feed](https://github.com/tontof/kriss_feed)
 - [Kune](https://en.wikipedia.org/wiki/Kune_%28software%29)
 - [Loomio](https://www.loomio.org)
-- [The Lounge](https://thelounge.github.io)
+- [The Lounge](https://thelounge.github.io), cf. https://github.com/Kloadut/shout_ynh/issues/4
 - [LSTU](https://github.com/ldidry/lstu)
 - [Lufi](https://git.framasoft.org/luc/lufi)
 - [MaidSafe](http://maidsafe.net)


### PR DESCRIPTION
See https://github.com/Kloadut/shout_ynh/issues/4

Creating a package for The Lounge is hopefully not going to be too difficult, and most of the specifics should already be highlighted in [this unmaintained repo](https://github.com/Kloadut/shout_ynh).