### PR TITLE
demo: update information

### DIFF
--- a/try.md
+++ b/try.md
@@ -1,7 +1,7 @@
 #Try YunoHost
 
 <div class="alert alert-warning" markdown="1">
-**Note:** This demo server runs a **beta version** of the software and **will fail** from time to time.    
+**Note:** This demo server could be down from time to time.
 <br>
 If it does not work, do consider [trying it at home](/try_at_home).
 
@@ -24,5 +24,5 @@ If it does not work, do consider [trying it at home](/try_at_home).
 
 <p class="text-center" markdown="1">
 ***Demo server gracefully provided by    
-<a href="https://www.web4all.fr/" target="_blank"><img src="/images/web4all.png" width=100 style="vertical-align: center"></a>***
+<a href="https://www.gitoyen.net" target="_blank">Gitoyen</a>***
 </p>

--- a/try_fr.md
+++ b/try_fr.md
@@ -1,7 +1,7 @@
 #Essayer YunoHost
 
 <div class="alert alert-warning" markdown="1">
-**Note :** Cette démo tourne sous une **version bêta** du logiciel et **va cesser de fonctionner** de temps en temps.
+**Note :** Cette démo peut cesser de fonctionner de temps en temps.
 <br>
 Si cela ne fonctionne pas, vous pouvez [essayer chez vous](/try_at_home_fr).
 
@@ -24,7 +24,7 @@ Si cela ne fonctionne pas, vous pouvez [essayer chez vous](/try_at_home_fr).
 
 <p class="text-center" markdown="1">
 ***Le serveur de démo est fourni généreusement par    
-<a href="https://www.web4all.fr/" target="_blank"><img src="/images/web4all.png" width=100 style="vertical-align: center"></a>***
+<a href="https://www.gitoyen.net" target="_blank">Gitoyen</a>***
 </p>
 
 


### PR DESCRIPTION
- replace web4all provider by gitoyen.
- remove warning that demo is in beta state.
- do we remove no more used images from the repository? like for web4all image.
- We did not replace by [Gitoyen logo](https://fr.wikipedia.org/wiki/Fichier:Gitoyen_logo.jpg) which is ugly and under ©.