### PR TITLE
[enh] Add YEP 1.3 about licensing information

### DIFF
--- a/packaging_apps_guidelines_fr.md
+++ b/packaging_apps_guidelines_fr.md
@@ -118,17 +118,17 @@ TODO Lien ou information pour réaliser l'inscription.
 #### YEP 1.3 - Indiquer la licence associée au paquet  | brouillon | AUTO | WORKING |
 La licence du paquet est à indiquer dans un fichier `LICENSE` à la racine du paquet. Attention à ne pas confondre avec la licence de l'application qui va être installée dont l'acronyme est à renseigner dans le champ `license` du manifeste.
 
-Les listes d'applications official.json et community.json n'acceptent que les paquets dont la licence est libre, de même pour la licence de l'application contenue. Certaines applications libres nécessitent des dépendances non-libres (exemple: mp3, drivers, etc.). Dans ce cas, il faut ajouter `+dep-non-free` à l'acronyme et si possible donner des précisions dans le README.md du paquet, l'intégration sera dans ce cas acceptée au cas par cas.
+Les listes d'applications official.json et community.json n'acceptent que les paquets dont la licence est libre, de même pour la licence de l'application contenue. Certaines applications libres nécessitent des dépendances non-libres (exemple: mp3, drivers, etc.). Dans ce cas, il faut ajouter `&dep-non-free` à l'acronyme et si possible donner des précisions dans le README.md du paquet, l'intégration sera dans ce cas acceptée au cas par cas.
 
-Dans le futur, YunoHost affichera sans doute des détails sur la licence de l'application. Pour y parvenir, l'acronyme doit être celui issu de cette [liste de licences répertoriées sur gnu.org](https://www.gnu.org/licenses/license-list.fr.html) (si il y a 2 acronymes, il faut prendre celui contenant le numéro de version). Pour plus de cohérence, la casse doit être respectée.
+Dans le futur, YunoHost affichera sans doute des détails sur la licence de l'application. Pour y parvenir, l'acronyme doit être celui issu de cette [liste de licences répertoriées du SPDX](https://spdx.org/licenses/) (si il y a 2 acronymes, il faut prendre celui contenant le numéro de version). Pour plus de cohérence, la casse doit être respectée.
 
 Si la licence n'est pas présente dans la liste, dans ce cas il faut indiquer `free` ou `non-free` selon qu'elle est libre ou non et donner l'occasion à l'utilisateur de se renseigner dans le README.md (lien, explications, ...).
 
-Exemple: pour une licence `GNU Lesser General Public License (LGPL), version 3` l'acronyme est `LGPLv3` si toutefois des dépendances non libres sont utilisées dans ce cas il faudra mettre `LGPLv3+dep-non-free` dans le manifeste.
+Exemple: pour une licence `GNU Lesser General Public License (LGPL), version 3` l'acronyme est `LGPL-3.0` si toutefois des dépendances non libres sont utilisées dans ce cas il faudra mettre `LGPL-3.0&dep-non-free` dans le manifeste.
 
-Si une application a des modules liés avec une autre licence (Exemple: Odoo 9 LGPLv3 + un module sous licence AGPLv3 ), dans ce cas on indiquera les deux licences séparées par un `+`.
+Si une application a des modules liés avec une autre licence (Exemple: Odoo 9 LGPL-3.0 + un module sous licence AGPL-3.0 ), dans ce cas on indiquera les deux licences séparées par un `&`.
 
-Si deux applications distinctes sont dans le même paquet d'installation et ont des licences distinctes, dans ce cas on peut utiliser le `&` pour séparer les licences.
+Si deux applications distinctes sont dans le même paquet d'installation et ont des licences distinctes, dans ce cas on peut utiliser le `,` pour séparer les licences.
 
 Dans les deux cas, le mainteneur est encouragé à réfléchir à la possibilité de créer deux paquets distincts. Le manifeste permet des questions de type `app` de façon à faire référence à une autre application déjà installée.
 

--- a/packaging_apps_guidelines_fr.md
+++ b/packaging_apps_guidelines_fr.md
@@ -130,7 +130,9 @@ Si une application a des modules liés avec une autre licence (Exemple: Odoo 9 L
 
 Si deux applications distinctes sont dans le même paquet d'installation et ont des licences distinctes, dans ce cas on peut utiliser le `,` pour séparer les licences.
 
-Dans les deux cas, le mainteneur est encouragé à réfléchir à la possibilité de créer deux paquets distincts. Le manifeste permet des questions de type `app` de façon à faire référence à une autre application déjà installée.
+Dans les deux cas, le mainteneur est encouragé à réfléchir à la possibilité de créer deux paquets distincts. Le manifeste de chaque application permet de poser des questions de type `app` de façon à faire référence à une autre application déjà installée.
+
+Rappel: une question de type `app` prend pour réponse l'identifiant d'une des apps déjà installée.
 
 Quelques liens intéressants pour aider au choix de licence:
 * [Des fiches explicatives sur les licences libres](https://www.inria.fr/content/download/5896/48452/version/2/file/INRIA_recueil_fiches_licences_libres_vf.pdf)

--- a/packaging_apps_guidelines_fr.md
+++ b/packaging_apps_guidelines_fr.md
@@ -120,7 +120,7 @@ La licence du paquet est à indiquer dans un fichier `LICENSE` à la racine du p
 
 Les listes d'applications official.json et community.json n'acceptent que les paquets dont la licence est libre, de même pour la licence de l'application contenue. Certaines applications libres nécessitent des dépendances non-libres (exemple: mp3, drivers, etc.). Dans ce cas, il faut ajouter `+dep-non-free` à l'acronyme et si possible donner des précisions dans le README.md du paquet, l'intégration sera dans ce cas acceptée au cas par cas.
 
-Dans le future, YunoHost affichera sans doute des détails sur la licence de l'application. Pour y parvenir, l'acronyme doit être celui issue de cette [liste de licences répertoriées sur gnu.org](https://www.gnu.org/licenses/license-list.fr.html) (si il y a 2 acronymes, il faut prendre celui contenant le numéro de version). Pour plus de cohérence, la casse doit être respectée.
+Dans le futur, YunoHost affichera sans doute des détails sur la licence de l'application. Pour y parvenir, l'acronyme doit être celui issu de cette [liste de licences répertoriées sur gnu.org](https://www.gnu.org/licenses/license-list.fr.html) (si il y a 2 acronymes, il faut prendre celui contenant le numéro de version). Pour plus de cohérence, la casse doit être respectée.
 
 Si la licence n'est pas présente dans la liste, dans ce cas il faut indiquer `free` ou `non-free` selon qu'elle est libre ou non et donner l'occasion à l'utilisateur de se renseigner dans le README.md (lien, explications, ...).
 

--- a/packaging_apps_guidelines_fr.md
+++ b/packaging_apps_guidelines_fr.md
@@ -115,7 +115,30 @@ TODO Lien ou information pour réaliser l'inscription.
 </b>
 </div>
 
-#### YEP 1.3 - Indiquer la licence associée au paquet  | validé | AUTO | WORKING |
+#### YEP 1.3 - Indiquer la licence associée au paquet  | brouillon | AUTO | WORKING |
+La licence du paquet est à indiquer dans un fichier `LICENSE` à la racine du paquet. Attention à ne pas confondre avec la licence de l'application qui va être installée dont l'acronyme est à renseigner dans le champ `license` du manifeste.
+
+Les listes d'applications official.json et community.json n'acceptent que les paquets dont la licence est libre, de même pour la licence de l'application contenue. Certaines applications libres nécessitent des dépendances non-libres (exemple: mp3, drivers, etc.). Dans ce cas, il faut ajouter `+dep-non-free` à l'acronyme et si possible donner des précisions dans le README.md du paquet, l'intégration sera dans ce cas acceptée au cas par cas.
+
+Dans le future, YunoHost affichera sans doute des détails sur la licence de l'application. Pour y parvenir, l'acronyme doit être celui issue de cette [liste de licences répertoriées sur gnu.org](https://www.gnu.org/licenses/license-list.fr.html) (si il y a 2 acronymes, il faut prendre celui contenant le numéro de version). Pour plus de cohérence, la casse doit être respectée.
+
+Si la licence n'est pas présente dans la liste, dans ce cas il faut indiquer `free` ou `non-free` selon qu'elle est libre ou non et donner l'occasion à l'utilisateur de se renseigner dans le README.md (lien, explications, ...).
+
+Exemple: pour une licence `GNU Lesser General Public License (LGPL), version 3` l'acronyme est `LGPLv3` si toutefois des dépendances non libres sont utilisées dans ce cas il faudra mettre `LGPLv3+dep-non-free` dans le manifeste.
+
+Si une application a des modules liés avec une autre licence (Exemple: Odoo 9 LGPLv3 + un module sous licence AGPLv3 ), dans ce cas on indiquera les deux licences séparées par un `+`.
+
+Si deux applications distinctes sont dans le même paquet d'installation et ont des licences distinctes, dans ce cas on peut utiliser le `&` pour séparer les licences.
+
+Dans les deux cas, le mainteneur est encouragé à réfléchir à la possibilité de créer deux paquets distincts. Le manifeste permet des questions de type `app` de façon à faire référence à une autre application déjà installée.
+
+Quelques liens intéressants pour aider au choix de licence:
+* [Des fiches explicatives sur les licences libres](https://www.inria.fr/content/download/5896/48452/version/2/file/INRIA_recueil_fiches_licences_libres_vf.pdf)
+* [La documentation sur les licences du projet GNU](https://www.gnu.org/licenses/licenses.fr.html)
+* [Un guide du projet GNU pour aider au choix d'une licence](https://www.gnu.org/licenses/license-recommendations.fr.html)
+
+
+
 #### YEP 1.4 - Informer sur l'intention de maintenir un paquet   | brouillon | manuel | WORKING |
 #### YEP 1.5 - Mettre à jour régulièrement le statut de l'app  | brouillon | manuel | WORKING |
 #### YEP 1.6 - Se tenir informé sur l'évolution du packaging d'apps  | validé | manuel | OFFICIAL |
@@ -133,7 +156,7 @@ Les scripts d'action (install, upgrade, remove, backup et restore) doivent être
 Ceci étant rien n'empèche à l'intérieur de ces scripts de faire appel à d'autres scripts ou bibliothèques de fonction. Ceux ci ne sont pas obligés d'être en bash.
 
 Cependant, il faudra porter une attention particulière à l'affichage correcte des logs d'information, de warning, ou d'erreurs. Afin qu'un utilisateur de la cli/api yunohost puisse comprendre le fonctionnement du script venant d'être executé et au besoin réparer son instance YunoHost.
- 
+
 #### YEP 2.3 - Sauvegarder les réponses lors de l'installation  | validé | manuel | WORKING |
 Lors de l'installation, il est nécessaire de sauvegarder chaque réponse aux questions du manifeste. En effet, même si au début il n'est pas nécessaire d'écrire un script de mise à jour, par la suite ce sera sans doute le cas. Or, sans les informations initiales, la mise à jour peut être plus fastidieuse.
 


### PR DESCRIPTION
This YEP is a draft about how inform user about app or package license. Some points regarding how to fill licence in manifest.json may be unconsensual.

---------------

Cette YEP est un brouillon à propos de la façon dont les licences doivent être indiquées dans les paquets. Certains points à propos de la façon de remplir le champ licence dans le manifeste peuvent faire débat.
