### PR TITLE
Add explaination about XMPP chat rooms of YunoHost project.

### DIFF
--- a/chat_rooms.md
+++ b/chat_rooms.md
@@ -1,0 +1,26 @@
+## Chat rooms
+
+Amoung other communication tools, YunoHost project use chat rooms to communicate.
+
+This instant messaging chat rooms, which uses [XMPP protocol](XMPP_en), are hosted on our XMPP server.
+
+You could join this chat rooms with an [XMPP client](https://en.wikipedia.org/wiki/Comparison_of_instant_messaging_clients#XMPP-related_features).
+
+### Chat rooms
+#### Mutual aid
+[Mutual aid](support_en) chat room is here to allow YunoHost's users to help each other.
+
+- A [web client](https://chat.yunohost.org) is here to easily join _mutual aid_ chat room.
+- **[support@conference.yunohost.org](xmpp:support@conference.yunohost.org?join)**
+
+#### Development
+YunoHost core development chat room.
+- **[dev@conference.yunohost.org](xmpp:dev@conference.yunohost.org?join)**
+
+#### Applications
+Application packaging development chat room. It allow packagers to help each other.
+It also allow to discuss packaging evolution, continuous integration tools.
+- **[apps@conference.yunohost.org](xmpp:apps@conference.yunohost.org?join)**
+
+### Discussions logs
+Discussions are logged during four days.

--- a/chat_rooms.md
+++ b/chat_rooms.md
@@ -14,13 +14,11 @@ You could join this chat rooms with an [XMPP client](https://en.wikipedia.org/wi
 - **[support@conference.yunohost.org](xmpp:support@conference.yunohost.org?join)**
 
 #### Development
-YunoHost core development chat room.
+YunoHost core development chat room. Currently, the main chat room for contributions on YunoHost project.
+For help, thanks to do it on `support` chat room.
 - **[dev@conference.yunohost.org](xmpp:dev@conference.yunohost.org?join)**
 
 #### Applications
 Application packaging development chat room. It allow packagers to help each other.
 It also allow to discuss packaging evolution, continuous integration tools.
 - **[apps@conference.yunohost.org](xmpp:apps@conference.yunohost.org?join)**
-
-### Discussions logs
-Discussions are logged during four days.

--- a/chat_rooms_fr.md
+++ b/chat_rooms_fr.md
@@ -1,0 +1,26 @@
+## Salons de discussions
+
+Parmi d’autres outils de communications, le projet YunoHost se sert de salons de discussions pour communiquer.
+
+Ces salons de messagerie instantanées, qui utilisent le [protocole XMPP](XMPP_fr), sont hébergés sur notre serveur XMPP.
+
+Vous pouvez rejoindre ces salons avec un [client XMPP](https://fr.wikipedia.org/wiki/Liste_de_clients_XMPP).
+
+### Salons
+#### Entraide
+Salon d’[entraide](support_fr) est là pour permettre aux utilisateurs de YunoHost de s’entraider.
+
+- Un [client web](https://chat.yunohost.org) est à votre disposition pour rejoindre facilement le salon d’entraide.
+- **[support@conference.yunohost.org](xmpp:support@conference.yunohost.org?join)**
+
+#### Développement
+Salon de développement du cœur de YunoHost.
+- **[dev@conference.yunohost.org](xmpp:dev@conference.yunohost.org?join)**
+
+#### Applications
+Salon de développement du packaging d’application. Il permet aux packageurs de s’entraider.
+Il sert également à discuter de l’évolution du packaging, des outils d’intégration continue sur les applications.
+- **[apps@conference.yunohost.org](xmpp:apps@conference.yunohost.org?join)**
+
+### Historique des discussions
+L’historique des discussions sont enregistrées pendant quatre jours.

--- a/chat_rooms_fr.md
+++ b/chat_rooms_fr.md
@@ -14,13 +14,11 @@ Salon d’[entraide](support_fr) est là pour permettre aux utilisateurs de Yuno
 - **[support@conference.yunohost.org](xmpp:support@conference.yunohost.org?join)**
 
 #### Développement
-Salon de développement du cœur de YunoHost.
+Salon de développement du cœur de YunoHost. Actuellement utilisé comme salon principal pour les contributions autour du projet.
+Pour de l’aide, merci de le faire sur le salon d’entraide.
 - **[dev@conference.yunohost.org](xmpp:dev@conference.yunohost.org?join)**
 
 #### Applications
 Salon de développement du packaging d’application. Il permet aux packageurs de s’entraider.
 Il sert également à discuter de l’évolution du packaging, des outils d’intégration continue sur les applications.
 - **[apps@conference.yunohost.org](xmpp:apps@conference.yunohost.org?join)**
-
-### Historique des discussions
-L’historique des discussions sont enregistrées pendant quatre jours.

--- a/index.md
+++ b/index.md
@@ -95,6 +95,7 @@
       <a class="btn btn-lg btn-block btn-info" href="/docs">Documentation</a>
       <a class="btn btn-lg btn-block btn-success" href="/contribute">Get involved</a>
       <a class="btn btn-lg btn-block btn-warning" href="https://forum.yunohost.org/" target="_blank">Forum</a>
+      <a class="btn btn-lg btn-block btn-default" href="chat_rooms_en" target="_blank">Chat rooms</a>
       <a class="btn btn-lg btn-block btn-danger" href="https://forum.yunohost.org/c/announcement">Latest news</a>
       <a class="btn btn-lg btn-block btn-danger btn-support" href="/support">Support</a>
     </div>

--- a/index_fr.md
+++ b/index_fr.md
@@ -94,6 +94,7 @@
       <a class="btn btn-lg btn-block btn-info" href="/docs_fr">Documentation</a>
       <a class="btn btn-lg btn-block btn-success" href="/contribute_fr">Comment contribuer</a>
       <a class="btn btn-lg btn-block btn-warning" href="https://forum.yunohost.org" target="_blank">Forum</a>
+      <a class="btn btn-lg btn-block btn-default" href="chat_rooms_fr" target="_blank">Salons de discussions</a>
       <a class="btn btn-lg btn-block btn-danger" href="https://forum.yunohost.org/c/announcement">Dernières nouvelles</a>
       <a class="btn btn-lg btn-block btn-danger btn-support" href="/support_fr">Support</a>
 

--- a/sitemap.md
+++ b/sitemap.md
@@ -110,5 +110,6 @@
    * [Art Works](artworks_en)
    * [Blog](https://forum.yunohost.org/c/announcement)
    - [Forum](https://forum.yunohost.org)
+   - [Chat rooms](chat_rooms_en)
    * [Communication](communication_en)
    * [Help](/help)

--- a/sitemap_fr.md
+++ b/sitemap_fr.md
@@ -122,6 +122,7 @@
    * [Entraide - support](/support_fr)
    * [Blog](https://forum.yunohost.org/c/announcement)
    - [Forum](https://forum.yunohost.org)
+   - [Salons de discussions](chat_rooms_fr)
    * [Conférences](/conf_fr)
    * [Communication extérieure](communication_fr)
    * [Travail artistique](artworks_fr)


### PR DESCRIPTION
- french and english pages.
- add links on sitemaps and buttons on homepages.

----

- I need agreement about the fact that we publicly display this chat rooms.
  - As before, we were hiding this chat rooms.
- I also need agreement about the fact we give the link toward logs history.
- Then, I need proofreading, mostly on english version.