### PR TITLE
Add doc about DKIM dns configuration

### DIFF
--- a/dkim.md
+++ b/dkim.md
@@ -1,6 +1,7 @@
 # DKIM
 
 <div class="alert alert-danger">This page is deprecated. DKIM is now by default integrated in YunoHost with [Rspamd](https://rspamd.com)/rmilter.</div>
+Now you just need to add a zone in your DNS configuration according to the file /etc/dkim/yourdomainname.tld.mail.txt</div>
 
 
 ##### Note:

--- a/dkim_fr.md
+++ b/dkim_fr.md
@@ -1,6 +1,7 @@
 # DKIM
 
-<div class="alert alert-danger">Cette page n’est plus à jour. Le DKIM est a présent intégré par défaut dans YunoHost avec [Rspamd](https://rspamd.com)/rmilter.</div>
+<div class="alert alert-danger">Cette page n’est plus à jour. Le DKIM est a présent intégré par défaut dans YunoHost avec [Rspamd](https://rspamd.com)/rmilter.
+Il suffit désormais de créer une zone DNS en s'inspirant du fichier /etc/dkim/yourdomainname.tld.mail.txt</div>
 
 Le protocole SMTP ne prévoit pas de mécanisme de vérification de l’expéditeur. Il est donc possible d’envoyer un courrier avec une adresse d’expéditeur factice ou usurpée. SPF et DKIM sont deux mécanismes d’authentification de l’expéditeur d’un email.
 

--- a/dns_config.md
+++ b/dns_config.md
@@ -2,6 +2,13 @@
 
 Sample DNS zone configuration for `domain.tld` domain name:
 
+#### Use yunohost command to generate my DNS ZONE
+
+Connect to your server using yunohost and run the following as root
+```bash
+yunohost domain dns-conf domain.tld
+```
+
 #### Redirection from the domain name to the IP address
 ```bash
 @ 1800 IN A 111.222.333.444 # (Minimal) IPv4
@@ -37,6 +44,8 @@ vjud 1800 IN CNAME @
 @ 1800 IN MX 10 domain.tld. # (Minimal)
 @ 1800 IN TXT "v=spf1 a mx -all"
 ```
+
+You should also consult the [DKIM documentation](#/dkim). DKIM allows yours mails not to be considered by spam by other mail service. In fact DKIM ask you to add an entry in your zone.
 
 #### Set up
 Replace:

--- a/dns_config_fr.md
+++ b/dns_config_fr.md
@@ -2,6 +2,13 @@
 
 Exemple de configuration des entrées de la zone DNS pour le nom de domaine `domain.tld` :
 
+#### Utiliser la commande yunohost pour générer ma zone DNS
+
+Connecter vous à votre serveur et lancer la commande suivante.
+```bash
+yunohost domain dns-conf domain.tld
+```
+
 #### Redirection du nom de domaine vers l’adresse IP
 ```bash
 @ 1800 IN A 111.222.333.444 # (Minimum) IPv4
@@ -39,6 +46,8 @@ vjud 1800 IN CNAME @
 ```
 <br />
 
+Vous devriez aussi consulter [la documentation de DKIM](#/dkim_fr). DKIM permet d'éviter que vos mails soit considérés comme SPAM et DKIM nécessite une entrée spécifique dans votre zone DNS.
+
 #### Mise en place
 Remplacez :
 * « `domain.tld` » par votre propre nom de domaine en conservant le point à la fin.
@@ -53,5 +62,5 @@ Les entrées DNS sous domaines, XMPP et email ne fonctionnent pas sans une redir
 <div class="alert alert-warning">**Attention :** le **@** représente le nom de domaine par défaut que l’on est en train de définir, certains bureaux d’enregistrement ne l’acceptent pas (ex : OVH). Il faut donc remplacer le « @ » par votre nom de domaine (domain.tld**.**) sans oublier un point à la fin.</div>
 
 #### Time to live
-Toutes les entrées DNS ci-dessus ont la valeur `1800` (30 minutes). Elle correspond au 
+Toutes les entrées DNS ci-dessus ont la valeur `1800` (30 minutes). Elle correspond au
 [Time to live (TTL)](https://fr.wikipedia.org/wiki/Time_to_Live#Le_Time_to_Live_dans_le_DNS) qui représente et indique le temps, en secondes, durant lequel l’entrée DNS peut être conservée en cache. Passé ce délai, l’information doit être considérée comme obsolète et doit être mise à jour.


### PR DESCRIPTION
Salut, j'ai un peu beugué en voyant que http://www.mail-tester.com/ me dit que mon serveur de mail ne donne pas de clef DKIM alors que la documentation dit que ça marche out of the box.
Il me semble qu'il faut quand même toujours ajouter la zone qu'il faut sur le DNS, et il m'a fallu regarder la conf de rmilter pour découvrir l'existence de /etc/dkim/*.
Du coup, je fais une miniproposition d'amélioration à la documentation.
Je pense aussi que ça serait cool de rajouter un liens vers DKIM et SPF dans la page configuration de votre DNS qu'est ce que vous en pensez ?
Pourquoi pas carrément faire un script à lancer dans bash pour avoir une zone toute fait à copier/coller, je me lancerais bien la dedans si ça vous dit aussi.

Votre projet est super en tout cas. Merci beaucoup.

--
Too lazy for english translation but if needed just ask me ;-)