### PR TITLE
[enh] update install_iso

### DIFF
--- a/install_iso.md
+++ b/install_iso.md
@@ -8,27 +8,13 @@
 <img src="/images/desktop.jpg">
 <img src="/images/nettop.jpg">
 
-<div class="alert alert-danger">These images are based on **Debian Wheezy**. Wheezy **won't be maintained** with YunoHost 2.4.<br />
-It is **strongly recommended** to install YunoHost on **Debian Jessie** with the **[install script](/install_on_debian_en)**.</div>
-
 * A x86-compatible hardware dedicated to YunoHost: laptop, nettop, netbook, desktop.    
 You can use any computer with **256MB RAM or more**.
 * Another computer to read this guide and access to your server.
 * A [reasonable ISP](/isp), preferably with a good and unlimited upstream bandwidth
 * A **USB stick** of at least 1GB capacity **OR** a standard **blank CD**
 * One of the latest **YunoHost ISO images**, available here (take the 32 Bits one if you don't know which one to choose):
-   <div>
-   <b>Torrent:</b>
-   <ul>
-   <li>[32 bits](http://build.yunohost.org/yunohostv2-latest-i386.iso.torrent)</li>
-   <li>[64 bits](http://build.yunohost.org/yunohostv2-latest-amd64.iso.torrent)</li>
-   </ul>
-   <b>Direct download:</b>
-   <ul>
-   <li>[32 bits](http://build.yunohost.org/yunohostv2-latest-i386.iso)</li>
-   <li>[64 bits](http://build.yunohost.org/yunohostv2-latest-amd64.iso)</li>
-   </ul>
-   </div>
+ - https://build.yunohost.org
 
 ---
 

--- a/install_iso_fr.md
+++ b/install_iso_fr.md
@@ -8,26 +8,12 @@
 <img src="/images/desktop.jpg">
 <img src="/images/nettop.jpg">
 
-<div class="alert alert-danger">Ces images sont basées sur **Debian Wheezy**. Wheezy **ne sera plus maintenue** avec YunoHost 2.4.<br />
-Il est **fortement conseillé** d’installer YunoHost sur **Debian Jessie** avec le **[script d’installation](/install_on_debian_fr)**.</div>
-
 * Un matériel compatible x86 dédié à YunoHost : portable, netbook, ordinateur. Vous pouvez réutiliser n’importe quelle machine avec **256 Mo de RAM minimum**
 * Un autre ordinateur pour parcourir ce guide et accéder à votre serveur
 * Un [fournisseur d’accès correct](/isp_fr), de préférence avec une bonne vitesse d’upload
 * Une **clé USB** d’une capacité minimum d’1Go **OU** un **CD vierge** standard
 * Une des dernières **images ISO YunoHost** (dans le doute prenez la version 32 bits) :
-    <div>
-    <b>Torrent :</b>
-    <ul>
-    <li>[32 bits](http://build.yunohost.org/yunohostv2-latest-i386.iso.torrent)</li>
-    <li>[64 bits](http://build.yunohost.org/yunohostv2-latest-amd64.iso.torrent)</li>
-    </ul>
-    <b>Téléchargement direct :</b>
-    <ul>
-    <li>[32 bits](http://build.yunohost.org/yunohostv2-latest-i386.iso)</li>
-    <li>[64 bits](http://build.yunohost.org/yunohostv2-latest-amd64.iso)</li>
-    </ul>
-    </div>
+ - https://build.yunohost.org
 
 ---
 


### PR DESCRIPTION
### Done
- remove warning about outdated ISO
- Add link to builds for ISO.

### Todo
- `index2` –> `index`
- add direct link to ISOs?
- explain how to check checksums
- [install_on_virtualbox_fr](https://yunohost.org/#/install_on_virtualbox_fr), (_en) links toward ISO are not up to date.