### PR TITLE
[fix] "pallier à ça" ce n'est pas français

### DIFF
--- a/vpn_advantage_fr.md
+++ b/vpn_advantage_fr.md
@@ -29,7 +29,7 @@ Pour éviter ça il faut entre autre :
 
 Malheureusement, aucun des FAI français les plus courants ne respecte la totalité de ces points.
 
-Pour pallier à ça, l'usage d'un VPN respectant ces points peut être une alternative.
+Pour pallier cela, l'usage d'un VPN respectant ces points peut être une alternative.
 
 ### Confiance
 Enfin, si vous ne souhaitez pas que le contenu des communications de votre serveur soit espionnable par des équipements présent sur le réseau de votre Fournisseur d'Accès Internet, vous pouvez utiliser un VPN pour chiffrer vos communications et déporter votre confiance sur un fournisseur de VPN. Rappel, depuis 2015, le gouvernement déploie officiellement des boîtes noires chez les gros opérateurs réseau qui ont pour objectif de mettre sur écoute l'ensemble des communications numériques françaises entre autre pour préserver les intérêts scientifiques, économiques et industrielles de la France.


### PR DESCRIPTION
On dit "pallier cela" car "pallier" est un verbe transitif direct, donc suivi d'un COD et non d'un COI