### PR TITLE
Recommend to use the image when installing on RPi + update manual install

### DIFF
--- a/install_on_raspberry.md
+++ b/install_on_raspberry.md
@@ -12,14 +12,16 @@ Before setting up a server at home, it is recommended that you know the [possibl
 
 ## Pre-requisite
 
+- A Raspberry Pi 0, 1, 2 or 3 ;
 - An SD card: **8GB** capacity (at least) and **Class 10** speed rate are highly recommended (like the [Transcend 300x](http://www.amazon.fr/Transcend-microSDHC-adaptateur-TS32GUSDU1E-Emballage/dp/B00CES44EO)) ;
 - A power supply (either an adapter or a MicroUSB cable)
 - An ethernet cable (RJ-45) to connect your Raspberry Pi to your router. (Raspberry Pi Zero users can connect the Pi using an OTG cable, Wifi dongle and [following these instructions](https://davidmaitland.me/2015/12/raspberry-pi-zero-headless-setup/))
-- The **YunoHost Raspberry Pi image**, available on [build.yunohost.org](http://build.yunohost.org/). (Not needed if you want to manually install YunoHost on an existing Debian system.)
 
 ---
 
-## Installation using an image
+## Installation using the image (recommended)
+
+<a class="btn btn-lg btn-default" href="https://build.yunohost.org/">0. Download the pre-installed image for Raspberry Pi</a>
 
 <a class="btn btn-lg btn-default" href="/copy_image">1. Copy image to the SD card</a>
 
@@ -31,33 +33,28 @@ Before setting up a server at home, it is recommended that you know the [possibl
 
 ---
 
-## Manual installation
+## Manual installation (advanced users)
+
+<div class="alert alert-info" markdown="1">
+We do not recommend the manual installation because it is more technical and longer than using the pre-installed image. This documentation is only intended for advanced users.
+</div>
 
 <div class="alert alert-warning" markdown="1">
 The latest Rasbpian Jessie image requires a screen and a keyboard, as it is no longer possible to connect directly to the Raspberry through SSH. Nevertheless it is possible to re-enable SSH at boot : before starting your Raspberry, put in the boot partition of the SD card an empty file named `ssh` (without extension).
 </div>
 
-0. Install Raspbian Jessie Lite on the SD card ([instructions](https://www.raspberrypi.org/downloads/raspbian/)) and connect to your Pi.
+0. Install Raspbian Jessie Lite on the SD card ([instructions](https://www.raspberrypi.org/downloads/raspbian/)).
 
-1. The root user must have a password, or the installation will fail. To change the root password:
+1. Connect to your Raspberry Pi with the user `pi`. Set the root password with 
 ```bash
 sudo passwd root
 ```
 
-2. Install git
-```bash
-sudo apt-get install git
-```
+2. Edit `/etc/ssh/sshd_config` to allow ssh login for root, by replacing `PermitRootLogin without-password` with `PermitRootLogin yes`. Reload the ssh daemon with `service ssh reload`.
 
-2. Clone the Yunohost install script repository
-```bash
-git clone https://github.com/YunoHost/install_script /tmp/install_script
-```
+3. Disconnect and reconnect, this time as root.
 
-4. Execute the installation script
-```bash
-cd /tmp/install_script && sudo ./install_yunohost
-```
+4. Then follow the <a href="/install_manually">generic manual install procedure</a>.
 
 ---
 

--- a/install_on_raspberry.md
+++ b/install_on_raspberry.md
@@ -35,7 +35,7 @@ Before setting up a server at home, it is recommended that you know the [possibl
 
 ## Manual installation (advanced users)
 
-<div class="alert alert-info" markdown="1">
+<div class="alert alert-warning" markdown="1">
 We do not recommend the manual installation because it is more technical and longer than using the pre-installed image. This documentation is only intended for advanced users.
 </div>
 

--- a/install_on_raspberry_fr.md
+++ b/install_on_raspberry_fr.md
@@ -16,50 +16,45 @@ Avant d'héberger un serveur chez vous, il est recommandé de prendre connaissan
 - Une carte SD : au moins **8 Go** et **Classe 10** (par exemple une [Transcend 300x](http://www.amazon.fr/Transcend-microSDHC-adaptateur-TS32GUSDU1E-Emballage/dp/B00CES44EO)) ;
 - Un adaptateur secteur pour la alimenter la carte ;
 - Un câble ethernet/RJ-45 pour brancher la carte à votre routeur/box internet. Avec le Raspberry Pi Zero vous pouvez connecter votre carte avec un câble OTG et un adaptateur Wifi USB.
-- L'image YunoHost pour Raspberry Pi, à télécharger sur [build.yunohost.org](http://build.yunohost.org/).
 
 ---
 
-## Installation avec une image
+## Installation avec l'image (recommandée)
 
-<a class="btn btn-lg btn-default" href="/copy_image_fr">1. Copier l’image sur une carte SD</a>
+<a class="btn btn-lg btn-default" href="http://build.yunohost.org/">1. Télécharger l'image pour Raspberry Pi</a>
 
-<a class="btn btn-lg btn-default" href="/plug_and_boot_fr">2. Brancher & démarrer</a>
+<a class="btn btn-lg btn-default" href="/copy_image_fr">2. Copier l’image sur une carte SD</a>
 
-<a class="btn btn-lg btn-default" href="/ssh_fr">3. Se connecter en SSH</a>
+<a class="btn btn-lg btn-default" href="/plug_and_boot_fr">3. Brancher & démarrer</a>
 
-<a class="btn btn-lg btn-default" href="/postinstall_fr">4. Procéder à la post-installation</a>
+<a class="btn btn-lg btn-default" href="/ssh_fr">4. Se connecter en SSH</a>
+
+<a class="btn btn-lg btn-default" href="/postinstall_fr">5. Procéder à la post-installation</a>
 
 ---
 
-## Installation manuelle
+## Installation manuelle (déconseillée)
+
+<div class="alert alert-info" markdown="1">
+Nous déconseillons l'installation manuelle car elle plus technique et plus longue que l'installation via l'image pré-installée. Cette documentation est surtout destinée aux utilisateurs avancés.
+</div>
 
 <div class="alert alert-warning" markdown="1">
 Les dernières versions de Raspbian nécessitent un écran et un clavier, car il n'est plus possible de se connecter directement en SSH au Raspberry par défaut. Néanmoins, il est possible de réactiver le lancement de SSH au boot : il suffit de placer dans la partition boot de la carte SD un fichier nommé `ssh`, vide et sans extension.
 </div>
 
-0. Installez Raspbian Jessie Lite ([instructions](https://www.raspberrypi.org/downloads/raspbian/)) sur la carte SD puis connectez-vous en ssh au Raspberry Pi. 
+0. Installez Raspbian Jessie Lite ([instructions](https://www.raspberrypi.org/downloads/raspbian/)) sur la carte SD.
 
-
-1. L'user root doit avoir un mot de passe. (Si ce n'est pas le cas l'installation ne marchera pas.)
+1. Connectez-vous en ssh au Raspberry Pi avec l'utilisateur pi. Définissez un mot de passe root avec 
 ```bash
 sudo passwd root
 ```
 
-2. Installer git
-```bash
-sudo apt-get install git
-```
+2. Modifiez `/etc/ssh/sshd_config` pour autoriser root à se logger en ssh, en remplacant `PermitRootLogin without-password` par `PermitRootLogin yes`. Rechargez le daemon ssh avec `service ssh reload`, puis re-connectez-vous en root.
 
-3. Récupérer le script d'installation de Yunohost
-```bash
-git clone https://github.com/YunoHost/install_script /tmp/install_script
-```
+3. Déconnectez-vous et reconnectez-vous avec l'utilisateur root cette fois.
 
-4. Executez le script d' installation
-```bash
-cd /tmp/install_script && sudo ./install_yunohost
-```
+4. Poursuivez avec la <a href="/install_manually_fr">procédure d'installation manuelle générique</a>.
 
 ---
 

--- a/install_on_raspberry_fr.md
+++ b/install_on_raspberry_fr.md
@@ -35,7 +35,7 @@ Avant d'héberger un serveur chez vous, il est recommandé de prendre connaissan
 
 ## Installation manuelle (déconseillée)
 
-<div class="alert alert-info" markdown="1">
+<div class="alert alert-warning" markdown="1">
 Nous déconseillons l'installation manuelle car elle plus technique et plus longue que l'installation via l'image pré-installée. Cette documentation est surtout destinée aux utilisateurs avancés.
 </div>
 


### PR DESCRIPTION
On the support and on the forum, I see many user desperately trying to manually install from Raspbian and having trouble with it. The RPi image aims to make things much simpler and therefore we should recommend it.