### PR TITLE
[mod] remove '-p' from release version notation.

### DIFF
--- a/build_system.md
+++ b/build_system.md
@@ -80,7 +80,7 @@ $ dpkg-parsechangelog | grep "^Version" | cut -d ' ' -f 2
 $ head debian/changelog
 
 # Update changelog and do a proper tag (explained below)
-$ git yunobump x.y.z-p
+$ git yunobump x.y.z
 
 # Push the branch state AND the tags to the remote repository
 $ git push origin --tags testing:testing

--- a/build_system_fr.md
+++ b/build_system_fr.md
@@ -98,7 +98,7 @@ $ dpkg-parsechangelog | grep "^Version" | cut -d ' ' -f 2
 $ head debian/changelog
 
 # Update changelog and do a proper tag (explained below)
-$ git yunobump x.y.z-p
+$ git yunobump x.y.z
 
 # Push the branch state AND the tags to the remote repository
 $ git push origin --tags testing:testing


### PR DESCRIPTION
It's confusing on documentation.
I put `2.6.0-p` and it's not what I wanted.
I have to restart with `2.6.0`.
`-p` is used for what?
Can we remove it?
If it's usefull, we may display an other place with explanations.
