### PR TITLE
Add page for framasoft apps equivalence

### DIFF
--- a/apps_framasoft.md
+++ b/apps_framasoft.md
@@ -7,6 +7,7 @@
 | Framagit       | GitLab              | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/gitlab_ynh)          | ![](https://dash.yunohost.org/integration/gitlab.svg) |
 |                | Gogs                | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/gogs_ynh)            | ![](https://dash.yunohost.org/integration/gogs.svg) |
 | Framadrop      | Lufi                | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/lufi_ynh)            | ![](https://dash.yunohost.org/integration/lufi.svg) |
+| Framapiaf      | Mastodon            | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/mastodon_ynh)        | ![](https://dash.yunohost.org/integration/mastodon.svg) |
 | Framapic       | Lutim               | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/lutim_ynh)           | ![](https://dash.yunohost.org/integration/lutim.svg) |
 | Framabin       | PrivateBin          | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-apps/zerobin_ynh)         | ![](https://dash.yunohost.org/integration/zerobin.svg) |
 | Frama.link     | Lstu                | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/lstu_ynh)            | ![](https://dash.yunohost.org/integration/lstu.svg) |

--- a/apps_framasoft.md
+++ b/apps_framasoft.md
@@ -38,5 +38,6 @@
 
 ### Voir aussi
 
-[Liste complète des applications packagées](/apps)
+- [Liste complète des applications packagées](/apps)
+- [La roadmap 'Dégooglisons'](https://dev.yunohost.org/versions/12)
 

--- a/apps_framasoft.md
+++ b/apps_framasoft.md
@@ -24,7 +24,7 @@
 | Framemo        | Scrumblr            | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/scrumblr_ynh)        | ![](https://dash.yunohost.org/integration/scumblr.svg) |
 | Framinetest    | Minetest            | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/minetest_ynh)        | ![](https://dash.yunohost.org/integration/minetest.svg) |
 | Framatalk      | Jitsi Meet          | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/jitsi_ynh)           | ![](https://dash.yunohost.org/integration/jitsi.svg) |
-| Framalists     | Mailman             | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/mailman_ynh)         | ![](https://dash.yunohost.org/integration/mailman.svg) |
+| Framalistes    | Mailman             | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/mailman_ynh)         | ![](https://dash.yunohost.org/integration/mailman.svg) |
 |                | Sympa               | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/alexAubin/sympa_ynh)               | ![](https://dash.yunohost.org/integration/sympa.svg) |
 | Framindmap     | Wisemapping         | Non packagé                                          | |
 | Framavectoriel | SVG-Edit            | Non packagé                                          | |

--- a/apps_framasoft.md
+++ b/apps_framasoft.md
@@ -1,0 +1,41 @@
+# Équivalence avec les applications Framasoft
+
+| App Framasoft  | Équivalent          | Package                                                                                                | Status |
+| :---:          | :---:               | :---:                                                                                                  | :---:  |
+| Framapad       | Etherpad + mypads   | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/etherpad_mypads_ynh) | ![](https://dash.yunohost.org/integration/etherpad_mypads.svg) |
+| Framadrive     | Nextcloud           | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-apps/nextcloud_ynh)       | ![](https://dash.yunohost.org/integration/nextcloud.svg) |
+| Framagit       | GitLab              | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/gitlab_ynh)          | ![](https://dash.yunohost.org/integration/gitlab.svg) |
+|                | Gogs                | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/gogs_ynh)            | ![](https://dash.yunohost.org/integration/gogs.svg) |
+| Framadrop      | Lufi                | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/lufi_ynh)            | ![](https://dash.yunohost.org/integration/lufi.svg) |
+| Framapic       | Lutim               | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/lutim_ynh)           | ![](https://dash.yunohost.org/integration/lutim.svg) |
+| Framabin       | PrivateBin          | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-apps/zerobin_ynh)         | ![](https://dash.yunohost.org/integration/zerobin.svg) |
+| Frama.link     | Lstu                | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/lstu_ynh)            | ![](https://dash.yunohost.org/integration/lstu.svg) |
+| Framatube      | Mediadrop           | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/mediadrop_ynh)       | ![](https://dash.yunohost.org/integration/mediadrop.svg) |
+| Framanews      | TinyTinyRSS         | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-apps/ttrss_ynh)           | ![](https://dash.yunohost.org/integration/ttrss.svg) |
+| Framabee       | Searx               | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/searx_ynh)           | ![](https://dash.yunohost.org/integration/searx.svg) |
+| Framabag       | Wallabag            | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/wallabag_ynh)        | ![](https://dash.yunohost.org/integration/wallabag.svg) |
+| Framacalc      | Ethercalc           | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/ethercalc_ynh)       | ![](https://dash.yunohost.org/integration/ethercalc.svg) |
+| Framaboard     | Kanboard            | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/kanboard_ynh)        | ![](https://dash.yunohost.org/integration/kanboard.svg) |
+| Framadate      | OpenSondage         | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/opensondage_ynh)     | ![](https://dash.yunohost.org/integration/opensondage.svg) |
+| Framasphère    | Diaspora*           | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/aymhce/diaspora_ynh)               | ![](https://dash.yunohost.org/integration/diaspora.svg) |
+| Framabookin    | BicBucStriim        | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/BicBucStriim_ynh)    | ![](https://dash.yunohost.org/integration/BicBucStriim.svg) |
+| Framanotes     | Turtl               | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/Turtl_ynh)           | ![](https://dash.yunohost.org/integration/Turtl.svg) |
+| Framemo        | Scrumblr            | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/scrumblr_ynh)        | ![](https://dash.yunohost.org/integration/scumblr.svg) |
+| Framinetest    | Minetest            | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/minetest_ynh)        | ![](https://dash.yunohost.org/integration/minetest.svg) |
+| Framatalk      | Jitsi Meet          | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/jitsi_ynh)           | ![](https://dash.yunohost.org/integration/jitsi.svg) |
+| Framalists     | Mailman             | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/YunoHost-Apps/mailman_ynh)         | ![](https://dash.yunohost.org/integration/mailman.svg) |
+|                | Sympa               | [<span class="glyphicon glyphicon-gift"></span>](https://github.com/alexAubin/sympa_ynh)               | ![](https://dash.yunohost.org/integration/sympa.svg) |
+| Framindmap     | Wisemapping         | Non packagé                                          | |
+| Framavectoriel | SVG-Edit            | Non packagé                                          | |
+| Framacarte     | uMap                | Non packagé                                          | |
+| Framaforms     | WebForms?           | Non packagé                                          | |
+| Framaestro     | Framaestro          | Non packagé                                          | |
+| Framavox       | ?                   | Non packagé                                          | |
+| Framagenda     | (Agenda Nextcloud)  | Non packagé                                          | |
+| Framagames     | ?                   | Non packagé                                          | |
+| MyFrama        | ?                   | Non packagé                                          | |
+
+### Voir aussi
+
+[Liste complète des applications packagées](/apps)
+


### PR DESCRIPTION
Proposal to add this page which should be easier to read and maintain compared to the Redmine roadmap and the forum thread... Though maybe we should have a better display (like the /apps page).

![2017-10-24-210250_1366x768_scrot](https://user-images.githubusercontent.com/4533074/31962875-18c7236a-b8ff-11e7-852f-a2c710b57ba0.png)
