### PR TITLE
Add tips for installing with serial console only

### DIFF
--- a/install_iso.md
+++ b/install_iso.md
@@ -15,6 +15,7 @@ You can use any computer with **256MB RAM or more**.
 * A **USB stick** of at least 1GB capacity **OR** a standard **blank CD**
 * One of the latest **YunoHost ISO images**, available here (take the 32 Bits one if you don't know which one to choose):
  - https://build.yunohost.org
+* ***Particular case*** : If your server has no graphic card, [prepare iso for booting with serial port](https://github.com/luffah/debian-mkserialiso) ).
 
 ---
 

--- a/install_iso.md
+++ b/install_iso.md
@@ -15,7 +15,7 @@ You can use any computer with **256MB RAM or more**.
 * A **USB stick** of at least 1GB capacity **OR** a standard **blank CD**
 * One of the latest **YunoHost ISO images**, available here (take the 32 Bits one if you don't know which one to choose):
  - https://build.yunohost.org
-* ***Particular case*** : If your server has no graphic card, [prepare iso for booting with serial port](https://github.com/luffah/debian-mkserialiso) ).
+* ***Particular case*** : If your server has no graphic card, [prepare iso for booting with serial port](https://github.com/luffah/debian-mkserialiso).
 
 ---
 

--- a/install_iso_fr.md
+++ b/install_iso_fr.md
@@ -14,7 +14,7 @@
 * Une **clé USB** d’une capacité minimum d’1Go **OU** un **CD vierge** standard
 * Une des dernières **images ISO YunoHost** (dans le doute prenez la version 32 bits) :
  - https://build.yunohost.org
-* ***Cas particulier*** : Si votre serveur n'a pas de carte graphique, il faut [préparer un iso qui démarre sur le port série](https://github.com/luffah/debian-mkserialiso) ).
+* ***Cas particulier*** : Si votre serveur n'a pas de carte graphique, il faut [préparer un iso qui démarre sur le port série](https://github.com/luffah/debian-mkserialiso).
 
 ---
 

--- a/install_iso_fr.md
+++ b/install_iso_fr.md
@@ -14,6 +14,7 @@
 * Une **clé USB** d’une capacité minimum d’1Go **OU** un **CD vierge** standard
 * Une des dernières **images ISO YunoHost** (dans le doute prenez la version 32 bits) :
  - https://build.yunohost.org
+* ***Cas particulier*** : Si votre serveur n'a pas de carte graphique, il faut [préparer un iso qui démarre sur le port série](https://github.com/luffah/debian-mkserialiso) ).
 
 ---
 


### PR DESCRIPTION
I had some difficulties to install Yunohost on a PC-engine board. So i add a link with some docs and a script which allow to do the procedure easily.