### PR TITLE
Création page certificate_custom_fr.md sur ancien modèle certificate_fr avant LE

### DIFF
--- a/certificate_custom_fr.md
+++ b/certificate_custom_fr.md
@@ -50,19 +50,23 @@ En fonction de l’autorité d’enregistrement, des certificats intermédiaires
 
 > **Gandi**
 > ```bash
-> sudo wget https://www.gandi.net/static/CAs/GandiStandardSSLCA.pem -O ae_certs/intermediate_ca.pem```
+> sudo wget https://www.gandi.net/static/CAs/GandiStandardSSLCA.pem -O ae_certs/intermediate_ca.pem
+>```
 > Attention si votre certificat expire après le 01/01/2017, choisissez le certificat intermédiaire SHA2 suivant (à la place du certificat SHA1 précédent)
 > ```bash
-> sudo wget https://www.gandi.net/static/CAs/GandiStandardSSLCA2.pem -O ae_certs/intermediate_ca.pem```
+> sudo wget https://www.gandi.net/static/CAs/GandiStandardSSLCA2.pem -O ae_certs/intermediate_ca.pem
+>```
 
 > **RapidSSL**
 > ```bash
-> sudo wget https://knowledge.rapidssl.com/library/VERISIGN/INTERNATIONAL_AFFILIATES/RapidSSL/AR1548/RapidSSLCABundle.txt -O ae_certs/intermediate_ca.pem```
+> sudo wget https://knowledge.rapidssl.com/library/VERISIGN/INTERNATIONAL_AFFILIATES/RapidSSL/AR1548/RapidSSLCABundle.txt -O ae_certs/intermediate_ca.pem
+>```
 
 > **Cacert**
 > ```bash
 > sudo wget http://www.cacert.org/certs/root.crt -O ae_certs/ca.pem
-> sudo wget http://www.cacert.org/certs/class3.crt -O ae_certs/intermediate_ca.pem```
+> sudo wget http://www.cacert.org/certs/class3.crt -O ae_certs/intermediate_ca.pem
+>```
 
 Les certificats intermédiaires et root doivent être réunis avec le certificat obtenu pour créer une chaîne de certificats unifiés.
 
@@ -84,7 +88,7 @@ cat crt.pem key.pem
 
 Les certificats et la clé privée doivent ressembler à cela :
 
-`-----BEGIN CERTIFICATE-----`    
+`-----BEGIN CERTIFICATE-----`
 `MIICVDCCAb0CAQEwDQYJKoZIhvcNAQEEBQAwdDELMAkGA1UEBhMCRlIxFTATBgNV`
 `BAgTDENvcnNlIGR1IFN1ZDEQMA4GA1UEBxMHQWphY2NpbzEMMAoGA1UEChMDTExC`
 `MREwDwYDVQQLEwhCVFMgSU5GTzEbMBkGA1UEAxMSc2VydmV1ci5idHNpbmZvLmZy`
@@ -96,8 +100,8 @@ Les certificats et la clé privée doivent ressembler à cela :
 `BWm5xSqewM5QDYzXFt031DrPX63Fvo+tCKTQoVItdEuJPMahVsXnDyYHeUURRWLW`
 `wc0BzEgFZGGw7wiMF6wt5QIDAQABMA0GCSqGSIb3DQEBBAUAA4GBALD640iwKPMf`
 `pqdYtfvmLnA7CiEuao60i/pzVJE2LIXXXbwYjNAM+7Lov+dFT+b5FcOUGqLymSG3`
-`kSK6OOauBHItgiGI7C87u4EJaHDvGIUxHxQQGsUM0SCIIVGK7Lwm+8e9I2X0G2GP`    
-`9t/rrbdGzXXOCl3up99naL5XAzCIp6r5`  
+`kSK6OOauBHItgiGI7C87u4EJaHDvGIUxHxQQGsUM0SCIIVGK7Lwm+8e9I2X0G2GP`
+`9t/rrbdGzXXOCl3up99naL5XAzCIp6r5`
 `-----END CERTIFICATE-----`
 
 Enfin, sécurisez les fichiers de votre certificat.

--- a/certificate_custom_fr.md
+++ b/certificate_custom_fr.md
@@ -17,6 +17,7 @@ Depuis Windows, scp est exploitable avec putty, en téléchargeant l’outil [ps
 pscp -P 22 CERTIFICAT.crt admin@DOMAIN.TLD:ssl.crt
 pscp -P 22 CLE.key admin@DOMAIN.TLD:ssl.key```
 
+
 Dès lors que les fichiers sont sur le serveur, le reste du travail se fera sur celui-ci. En [ssh](https://yunohost.org/#/ssh_fr) ou en local.
 
 Tout d’abord, créez un dossier pour stocker les certificats obtenus.

--- a/certificate_custom_fr.md
+++ b/certificate_custom_fr.md
@@ -15,8 +15,8 @@ Depuis Windows, scp est exploitable avec putty, en téléchargeant l’outil [ps
 
 ```bash
 pscp -P 22 CERTIFICAT.crt admin@DOMAIN.TLD:ssl.crt
-pscp -P 22 CLE.key admin@DOMAIN.TLD:ssl.key```
-
+pscp -P 22 CLE.key admin@DOMAIN.TLD:ssl.key
+```
 
 Dès lors que les fichiers sont sur le serveur, le reste du travail se fera sur celui-ci. En [ssh](https://yunohost.org/#/ssh_fr) ou en local.
 
@@ -24,25 +24,29 @@ Tout d’abord, créez un dossier pour stocker les certificats obtenus.
 
 ```bash
 sudo mkdir /etc/yunohost/certs/DOMAIN.TLD/ae_certs
-sudo mv ssl.key ssl.crt /etc/yunohost/certs/DOMAIN.TLD/ae_certs/```
+sudo mv ssl.key ssl.crt /etc/yunohost/certs/DOMAIN.TLD/ae_certs/
+```
 
 Puis allez dans le dossier parent pour poursuivre.
 
 ```bash
-cd /etc/yunohost/certs/DOMAIN.TLD/```
+cd /etc/yunohost/certs/DOMAIN.TLD/
+```
 
 Faites une sauvegarde des certificats d’origine de yunohost, par précaution.
 
 ```bash
 sudo mkdir yunohost_self_signed
-sudo mv *.pem *.cnf yunohost_self_signed/```
+sudo mv *.pem *.cnf yunohost_self_signed/
+```
 
 En fonction de l’autorité d’enregistrement, des certificats intermédiaires et racines doivent être obtenus.
 
 > **StartSSL**
 > ```bash
 > sudo wget http://www.startssl.com/certs/ca.pem -O ae_certs/ca.pem
-> sudo wget http://www.startssl.com/certs/sub.class1.server.ca.pem -O ae_certs/intermediate_ca.pem```
+> sudo wget http://www.startssl.com/certs/sub.class1.server.ca.pem -O ae_certs/intermediate_ca.pem
+>```
 
 > **Gandi**
 > ```bash
@@ -63,17 +67,20 @@ En fonction de l’autorité d’enregistrement, des certificats intermédiaires
 Les certificats intermédiaires et root doivent être réunis avec le certificat obtenu pour créer une chaîne de certificats unifiés.
 
 ```bash
-cat ae_certs/ssl.crt ae_certs/intermediate_ca.pem ae_certs/ca.pem | sudo tee crt.pem```
+cat ae_certs/ssl.crt ae_certs/intermediate_ca.pem ae_certs/ca.pem | sudo tee crt.pem
+```
 
 La clé privée doit être, elle, convertie au format pem.
 
 ```bash
-sudo openssl rsa -in ae_certs/ssl.key -out key.pem -outform PEM```
+sudo openssl rsa -in ae_certs/ssl.key -out key.pem -outform PEM
+```
 
 Afin de s’assurer de la syntaxe des certificats, vérifiez le contenu des fichiers.
 
 ```bash
-cat crt.pem key.pem```
+cat crt.pem key.pem
+```
 
 Les certificats et la clé privée doivent ressembler à cela :
 
@@ -99,11 +106,12 @@ Enfin, sécurisez les fichiers de votre certificat.
 sudo chown root:metronome crt.pem key.pem
 sudo chmod 640 crt.pem key.pem
 sudo chown root:root -R ae_certs
-sudo chmod 600 -R ae_certs```
+sudo chmod 600 -R ae_certs
+```
 
 Rechargez la configuration de nginx pour prendre en compte le nouveau certificat.
 ```bash
-sudo service nginx reload```
-
+sudo service nginx reload
+```
 
 Votre certificat est prêt à servir. Vous pouvez toutefois vous assurez de sa mise en place en testant le certificat à l’aide du service de <a href="https://www.geocerts.com/ssl_checker" target="_blank">geocerts</a>. 

--- a/certificate_custom_fr.md
+++ b/certificate_custom_fr.md
@@ -1,4 +1,4 @@
-**Note :** depuis la version 2.5, Yunohost intègre la gestion automatisée de certificats Let's Encrypt. Vous pouvez donc facilement et gratuitement [installer un certificat Let's Encrypt](certificate_fr). Le document suivant décrit la méthodologie pour installer un certificat, payant, d'une autre autorité de certification (**Let's Encrypt**, **Gandi**, **RapidSSL**, **StartSSL**, **Cacert**).
+**Note :** depuis la version 2.5, Yunohost intègre la gestion automatisée de certificats Let's Encrypt. Vous pouvez donc facilement et gratuitement [installer un certificat Let's Encrypt](certificate_fr). Le document suivant décrit la méthodologie pour installer un certificat, payant, d'une autre autorité de certification (**Gandi**, **RapidSSL**, **StartSSL**, **Cacert**).
 
 ### Ajout d’un certificat signé par une autorité (autre que Let's Encrypt)
 

--- a/certificate_custom_fr.md
+++ b/certificate_custom_fr.md
@@ -50,10 +50,6 @@ En fonction de l’autorité d’enregistrement, des certificats intermédiaires
 
 > **Gandi**
 > ```bash
-> sudo wget https://www.gandi.net/static/CAs/GandiStandardSSLCA.pem -O ae_certs/intermediate_ca.pem
->```
-> Attention si votre certificat expire après le 01/01/2017, choisissez le certificat intermédiaire SHA2 suivant (à la place du certificat SHA1 précédent)
-> ```bash
 > sudo wget https://www.gandi.net/static/CAs/GandiStandardSSLCA2.pem -O ae_certs/intermediate_ca.pem
 >```
 
@@ -88,20 +84,20 @@ cat crt.pem key.pem
 
 Les certificats et la clé privée doivent ressembler à cela :
 
-`-----BEGIN CERTIFICATE-----`
-`MIICVDCCAb0CAQEwDQYJKoZIhvcNAQEEBQAwdDELMAkGA1UEBhMCRlIxFTATBgNV`
-`BAgTDENvcnNlIGR1IFN1ZDEQMA4GA1UEBxMHQWphY2NpbzEMMAoGA1UEChMDTExC`
-`MREwDwYDVQQLEwhCVFMgSU5GTzEbMBkGA1UEAxMSc2VydmV1ci5idHNpbmZvLmZy`
-`MB4XDTA0MDIwODE2MjQyNloXDTA0MDMwOTE2MjQyNlowcTELMAkGA1UEBhMCRlIx`
-`FTATBgNVBAgTDENvcnNlIGR1IFN1ZDEQMA4GA1UEBxMHQWphY2NpbzEMMAoGA1UE`
-`ChMDTExCMREwDwYDVQQLEwhCVFMgSU5GTzEYMBYGA1UEAxMPcHJvZi5idHNpbmZv`
-`LmZyMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSUagxPSv3LtgDV5sygt12`
-`kSbN/NWP0QUiPlksOkF2NkPfwW/mf55dD1hSndlOM/5kLbSBo5ieE3TgikF0Iktj`
-`BWm5xSqewM5QDYzXFt031DrPX63Fvo+tCKTQoVItdEuJPMahVsXnDyYHeUURRWLW`
-`wc0BzEgFZGGw7wiMF6wt5QIDAQABMA0GCSqGSIb3DQEBBAUAA4GBALD640iwKPMf`
-`pqdYtfvmLnA7CiEuao60i/pzVJE2LIXXXbwYjNAM+7Lov+dFT+b5FcOUGqLymSG3`
-`kSK6OOauBHItgiGI7C87u4EJaHDvGIUxHxQQGsUM0SCIIVGK7Lwm+8e9I2X0G2GP`
-`9t/rrbdGzXXOCl3up99naL5XAzCIp6r5`
+`-----BEGIN CERTIFICATE-----`<br/>
+`MIICVDCCAb0CAQEwDQYJKoZIhvcNAQEEBQAwdDELMAkGA1UEBhMCRlIxFTATBgNV`<br/>
+`BAgTDENvcnNlIGR1IFN1ZDEQMA4GA1UEBxMHQWphY2NpbzEMMAoGA1UEChMDTExC`<br/>
+`MREwDwYDVQQLEwhCVFMgSU5GTzEbMBkGA1UEAxMSc2VydmV1ci5idHNpbmZvLmZy`<br/>
+`MB4XDTA0MDIwODE2MjQyNloXDTA0MDMwOTE2MjQyNlowcTELMAkGA1UEBhMCRlIx`<br/>
+`FTATBgNVBAgTDENvcnNlIGR1IFN1ZDEQMA4GA1UEBxMHQWphY2NpbzEMMAoGA1UE`<br/>
+`ChMDTExCMREwDwYDVQQLEwhCVFMgSU5GTzEYMBYGA1UEAxMPcHJvZi5idHNpbmZv`<br/>
+`LmZyMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSUagxPSv3LtgDV5sygt12`<br/>
+`kSbN/NWP0QUiPlksOkF2NkPfwW/mf55dD1hSndlOM/5kLbSBo5ieE3TgikF0Iktj`<br/>
+`BWm5xSqewM5QDYzXFt031DrPX63Fvo+tCKTQoVItdEuJPMahVsXnDyYHeUURRWLW`<br/>
+`wc0BzEgFZGGw7wiMF6wt5QIDAQABMA0GCSqGSIb3DQEBBAUAA4GBALD640iwKPMf`<br/>
+`pqdYtfvmLnA7CiEuao60i/pzVJE2LIXXXbwYjNAM+7Lov+dFT+b5FcOUGqLymSG3`<br/>
+`kSK6OOauBHItgiGI7C87u4EJaHDvGIUxHxQQGsUM0SCIIVGK7Lwm+8e9I2X0G2GP`<br/>
+`9t/rrbdGzXXOCl3up99naL5XAzCIp6r5`<br/>
 `-----END CERTIFICATE-----`
 
 Enfin, sécurisez les fichiers de votre certificat.

--- a/certificate_custom_fr.md
+++ b/certificate_custom_fr.md
@@ -1,0 +1,108 @@
+**Note :** depuis la version 2.5, Yunohost intègre la gestion automatisée de certificats Let's Encrypt. Vous pouvez donc facilement et gratuitement [installer un certificat Let's Encrypt](certificate_fr). Le document suivant décrit la méthodologie pour installer un certificat, payant, d'une autre autorité de certification (**Let's Encrypt**, **Gandi**, **RapidSSL**, **StartSSL**, **Cacert**).
+
+### Ajout d’un certificat signé par une autorité (autre que Let's Encrypt)
+
+Après création du certificat auprès de votre autorité d’enregistrement, vous devez être en possession d’une clé privée, le fichier key et d’un certificat public, le fichier crt.
+> Attention, le fichier key est très sensible, il est strictement personnel et doit être très bien sécurisé.
+
+Ces deux fichiers doivent être copiés sur le serveur, s’ils ne s’y trouvent pas déjà.
+```bash
+scp CERTIFICAT.crt admin@DOMAIN.TLD:ssl.crt
+scp CLE.key admin@DOMAIN.TLD:ssl.key
+```
+
+Depuis Windows, scp est exploitable avec putty, en téléchargeant l’outil [pscp](http://the.earth.li/~sgtatham/putty/latest/x86/pscp.exe)
+
+```bash
+pscp -P 22 CERTIFICAT.crt admin@DOMAIN.TLD:ssl.crt
+pscp -P 22 CLE.key admin@DOMAIN.TLD:ssl.key```
+
+Dès lors que les fichiers sont sur le serveur, le reste du travail se fera sur celui-ci. En [ssh](https://yunohost.org/#/ssh_fr) ou en local.
+
+Tout d’abord, créez un dossier pour stocker les certificats obtenus.
+
+```bash
+sudo mkdir /etc/yunohost/certs/DOMAIN.TLD/ae_certs
+sudo mv ssl.key ssl.crt /etc/yunohost/certs/DOMAIN.TLD/ae_certs/```
+
+Puis allez dans le dossier parent pour poursuivre.
+
+```bash
+cd /etc/yunohost/certs/DOMAIN.TLD/```
+
+Faites une sauvegarde des certificats d’origine de yunohost, par précaution.
+
+```bash
+sudo mkdir yunohost_self_signed
+sudo mv *.pem *.cnf yunohost_self_signed/```
+
+En fonction de l’autorité d’enregistrement, des certificats intermédiaires et racines doivent être obtenus.
+
+> **StartSSL**
+> ```bash
+> sudo wget http://www.startssl.com/certs/ca.pem -O ae_certs/ca.pem
+> sudo wget http://www.startssl.com/certs/sub.class1.server.ca.pem -O ae_certs/intermediate_ca.pem```
+
+> **Gandi**
+> ```bash
+> sudo wget https://www.gandi.net/static/CAs/GandiStandardSSLCA.pem -O ae_certs/intermediate_ca.pem```
+> Attention si votre certificat expire après le 01/01/2017, choisissez le certificat intermédiaire SHA2 suivant (à la place du certificat SHA1 précédent)
+> ```bash
+> sudo wget https://www.gandi.net/static/CAs/GandiStandardSSLCA2.pem -O ae_certs/intermediate_ca.pem```
+
+> **RapidSSL**
+> ```bash
+> sudo wget https://knowledge.rapidssl.com/library/VERISIGN/INTERNATIONAL_AFFILIATES/RapidSSL/AR1548/RapidSSLCABundle.txt -O ae_certs/intermediate_ca.pem```
+
+> **Cacert**
+> ```bash
+> sudo wget http://www.cacert.org/certs/root.crt -O ae_certs/ca.pem
+> sudo wget http://www.cacert.org/certs/class3.crt -O ae_certs/intermediate_ca.pem```
+
+Les certificats intermédiaires et root doivent être réunis avec le certificat obtenu pour créer une chaîne de certificats unifiés.
+
+```bash
+cat ae_certs/ssl.crt ae_certs/intermediate_ca.pem ae_certs/ca.pem | sudo tee crt.pem```
+
+La clé privée doit être, elle, convertie au format pem.
+
+```bash
+sudo openssl rsa -in ae_certs/ssl.key -out key.pem -outform PEM```
+
+Afin de s’assurer de la syntaxe des certificats, vérifiez le contenu des fichiers.
+
+```bash
+cat crt.pem key.pem```
+
+Les certificats et la clé privée doivent ressembler à cela :
+
+`-----BEGIN CERTIFICATE-----`    
+`MIICVDCCAb0CAQEwDQYJKoZIhvcNAQEEBQAwdDELMAkGA1UEBhMCRlIxFTATBgNV`
+`BAgTDENvcnNlIGR1IFN1ZDEQMA4GA1UEBxMHQWphY2NpbzEMMAoGA1UEChMDTExC`
+`MREwDwYDVQQLEwhCVFMgSU5GTzEbMBkGA1UEAxMSc2VydmV1ci5idHNpbmZvLmZy`
+`MB4XDTA0MDIwODE2MjQyNloXDTA0MDMwOTE2MjQyNlowcTELMAkGA1UEBhMCRlIx`
+`FTATBgNVBAgTDENvcnNlIGR1IFN1ZDEQMA4GA1UEBxMHQWphY2NpbzEMMAoGA1UE`
+`ChMDTExCMREwDwYDVQQLEwhCVFMgSU5GTzEYMBYGA1UEAxMPcHJvZi5idHNpbmZv`
+`LmZyMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDSUagxPSv3LtgDV5sygt12`
+`kSbN/NWP0QUiPlksOkF2NkPfwW/mf55dD1hSndlOM/5kLbSBo5ieE3TgikF0Iktj`
+`BWm5xSqewM5QDYzXFt031DrPX63Fvo+tCKTQoVItdEuJPMahVsXnDyYHeUURRWLW`
+`wc0BzEgFZGGw7wiMF6wt5QIDAQABMA0GCSqGSIb3DQEBBAUAA4GBALD640iwKPMf`
+`pqdYtfvmLnA7CiEuao60i/pzVJE2LIXXXbwYjNAM+7Lov+dFT+b5FcOUGqLymSG3`
+`kSK6OOauBHItgiGI7C87u4EJaHDvGIUxHxQQGsUM0SCIIVGK7Lwm+8e9I2X0G2GP`    
+`9t/rrbdGzXXOCl3up99naL5XAzCIp6r5`  
+`-----END CERTIFICATE-----`
+
+Enfin, sécurisez les fichiers de votre certificat.
+
+```bash
+sudo chown root:metronome crt.pem key.pem
+sudo chmod 640 crt.pem key.pem
+sudo chown root:root -R ae_certs
+sudo chmod 600 -R ae_certs```
+
+Rechargez la configuration de nginx pour prendre en compte le nouveau certificat.
+```bash
+sudo service nginx reload```
+
+
+Votre certificat est prêt à servir. Vous pouvez toutefois vous assurez de sa mise en place en testant le certificat à l’aide du service de <a href="https://www.geocerts.com/ssl_checker" target="_blank">geocerts</a>. 

--- a/certificate_fr.md
+++ b/certificate_fr.md
@@ -10,11 +10,9 @@ En effet, les utilisateurs devront passer par un écran de ce type :
 Cet écran revient à demander **« Avez-vous confiance au serveur qui héberge ce site ? »**.
 Cela peut effrayer vos utilisateurs (à juste titre).
 
-Pour éviter cette confusion, il est possible d’obtenir un certificat signé par
-une autorité « connue » qui est **Let's Encrypt** et qui propose des
-certificats gratuits et reconnus directement par les navigateurs. YunoHost
-permet d'installer directement un tel certificat depuis l'interface
-d'administration ou la ligne de commande.
+Pour éviter cette confusion, il est possible d’obtenir un certificat, reconnu directement par les navigateurs, signé par une autorité « connue » : **Let's Encrypt**, **Gandi**, **RapidSSL**, **StartSSL**, **Cacert**.
+
+**Let's Encrypt** propose des certificats gratuits. YunoHost permet d'installer directement un tel certificat depuis l'interface d'administration ou la ligne de commande. La suite du document détaille l'installation et la gestion d'un tel certificat. Vous pouvez également [installer un certificat d'une autre autorité que Let's Encrypt](/custom_certificate_fr).
 
 ### Installer un certificat Let's Encrypt
 
@@ -92,4 +90,5 @@ HTTP depuis l'extérieur, vous pouvez tenter :
 
 - d'ajouter une ligne `127.0.0.1 votre.domaine.tld` au fichier `/etc/hosts` sur votre serveur ;
 - si l'installation ne fonctionne toujours pas, désactiver les vérifications en ajouter `--no-checks` à la commande `cert-install`.
+
 

--- a/certificate_fr.md
+++ b/certificate_fr.md
@@ -12,7 +12,7 @@ Cela peut effrayer vos utilisateurs (à juste titre).
 
 Pour éviter cette confusion, il est possible d’obtenir un certificat, reconnu directement par les navigateurs, signé par une autorité « connue » : **Let's Encrypt**, **Gandi**, **RapidSSL**, **StartSSL**, **Cacert**.
 
-**Let's Encrypt** propose des certificats gratuits. YunoHost permet d'installer directement un tel certificat depuis l'interface d'administration ou la ligne de commande. La suite du document détaille l'installation et la gestion d'un tel certificat. Vous pouvez également [installer un certificat d'une autre autorité que Let's Encrypt](/custom_certificate_fr).
+**Let's Encrypt** propose des certificats gratuits. Depuis la version 2.5, YunoHost permet d'installer directement un tel certificat depuis l'interface d'administration ou la ligne de commande. La suite du document détaille l'installation et la gestion d'un tel certificat. Vous pouvez également [installer un certificat d'une autre autorité que Let's Encrypt](/custom_certificate_fr).
 
 ### Installer un certificat Let's Encrypt
 

--- a/certificate_fr.md
+++ b/certificate_fr.md
@@ -12,7 +12,7 @@ Cela peut effrayer vos utilisateurs (à juste titre).
 
 Pour éviter cette confusion, il est possible d’obtenir un certificat, reconnu directement par les navigateurs, signé par une autorité « connue » : **Let's Encrypt**, **Gandi**, **RapidSSL**, **StartSSL**, **Cacert**.
 
-**Let's Encrypt** propose des certificats gratuits. Depuis la version 2.5, YunoHost permet d'installer directement un tel certificat depuis l'interface d'administration ou la ligne de commande. La suite du document détaille l'installation et la gestion d'un tel certificat. Vous pouvez également [installer un certificat d'une autre autorité que Let's Encrypt](/custom_certificate_fr).
+**Let's Encrypt** propose des certificats gratuits. Depuis la version 2.5, YunoHost permet d'installer directement un tel certificat depuis l'interface d'administration ou la ligne de commande. La suite du document détaille l'installation et la gestion d'un tel certificat. Vous pouvez également [installer un certificat d'une autre autorité que Let's Encrypt](/certificate_custom_fr).
 
 ### Installer un certificat Let's Encrypt
 


### PR DESCRIPTION
Salut,
Voilà une PR qui fait suite à la discussion sur ce commit https://github.com/YunoHost/doc/commit/16c3a5ece7c2587cb4582fef3be613426c98ab75#diff-315460731af6e6248463dd50f1e7f1f7
Il y a : 
* 1 nouvelle page certificate_custom_fr.md : elle reprend exactement l'ancien certificate_fr avant le commit cité précédemment + une petite note en intro pour rediriger vers la version à jour de certificate_fr
* 1 modif sur la page custom_fr.md : intègre un lien vers la nouvelle page
L'idée est vraiment que LE reste la solution conseillée par défaut.
Merci pour la relecture !
