### PR TITLE
packaging_apps_manifest: update 'version' field.

### DIFF
--- a/packaging_apps_manifest.md
+++ b/packaging_apps_manifest.md
@@ -12,7 +12,7 @@ The `manifest.json` file defines the app's constants, a bunch of values that Yun
         "fr": "Webmail Open Source"
     },
     "url": "http://roundcube.net/",
-    "version": "1.0-1",
+    "version": "1.0.1~ynh7",
     "license": "free",
     "maintainer": {
         "name": "kload",
@@ -63,7 +63,7 @@ The `manifest.json` file defines the app's constants, a bunch of values that Yun
 
 * **url**: software website.
 
-* **version**: version of the package builded from the upstream version number and an incremental number for each change in the package without upstream change. Example "1.0.0-7". Must be a string.
+* **version**: version of the package builded from the upstream version number and an incremental number for each change in the package without upstream change. Example "1.0.1~ynh7". Must be a string.
 
 * **license**: application license: `free` or `non-free`. Be careful to not confuse with package license which must be put in `LICENSE` file.
 

--- a/packaging_apps_manifest_fr.md
+++ b/packaging_apps_manifest_fr.md
@@ -12,7 +12,7 @@ Le fichier `manifest.json` définit les constantes de l’application, un ensemb
         "fr": "Webmail Open Source"
     },
     "url": "http://roundcube.net/",
-    "version": "1.0-1",
+    "version": "1.0.1~ynh7",
     "license": "free",
     "maintainer": {
         "name": "kload",
@@ -63,7 +63,7 @@ Le fichier `manifest.json` définit les constantes de l’application, un ensemb
 
 * **url** : site web de l’application.
 
-* **version** : version du package construit à partir du numéro de version de l’application qui est installée et d'un incrément pour chaque changement du paquet sans changement de version de l'application. "Exemple: 1.0.0-7". Le champ doit être une chaîne de caractères.
+* **version** : version du package construit à partir du numéro de version de l’application qui est installée et d'un incrément pour chaque changement du paquet sans changement de version de l'application. "Exemple: 1.0.1~ynh7". Le champ doit être une chaîne de caractères.
 
 * **license** : licence avec laquelle l’application est distribuée : `free`, `non-free`. Attention à ne pas confondre avec la licence du paquet qui doit être mise dans le fichier `LICENSE`.
 


### PR DESCRIPTION
Problem
-----------
Actually the separation between the upstream version and the package version is `-`. But some upstream version use already this char so the result might be trycky.

I found this page witch explain that : https://en.wikipedia.org/wiki/Software_versioning#Separating_sequences

For example, if we use the debian package for mumble we have this :
- The upstream version (debian version) : `1.2.18-1`
- The yunohost review : 5
- The result would be : `1.2.18-1-5`

An other example with pgadmin :
- The upstream version : `4-2.1`
- The yunohost review : 5
- The result would be : `4-2.1-5`

Purpose
----------
Using a more specific separation like that : `~ynh`
The result would be  : `<upstreamversion>~ynh<packageversion>`
With the last example the result would be that : `4-2.1~ynh5`

