### PR TITLE
L'autentification sur le relai orange se fait avec l'adresse mail

### DIFF
--- a/isp_orange_fr.md
+++ b/isp_orange_fr.md
@@ -53,7 +53,7 @@ ajouter
 
 ```bash
 # mdp_fai.conf
-[smtp.orange.fr]:25  user:mdp
+[smtp.orange.fr]:25  adresseemail@chez.orange:son-mot-de-passe
 ```
 avec votre mot de passe du compte d'orange.
 


### PR DESCRIPTION
C.f. ce post qui semble dire qu'il faut faire comme ça : https://forum.yunohost.org/t/resolu-livebox-orange-envoi-emails-impossibles-port-25-semble-bloque/4425