### PR TITLE
Rework the SD flashing doc, in particular to use Etcher

### DIFF
--- a/copy_image.md
+++ b/copy_image.md
@@ -1,46 +1,46 @@
-# Copy an image to an SD card
+# Flashing an SD card
 
-Now that you have the YunoHost image, you have to copy its content to an SD card.    
-The process differs regarding your operating system.
+Now that you download the YunoHost image, you have to copy its content to an SD
+card. This step is also sometimes called 'flashing' the SD card.
+
+<div class="alert alert-warning" markdown="1">
+In the context of self-hosting, it is recommended that your SD card be at least
+8 GB (to have a reasonable space available for the system and a few data) and at 
+least Class 10 (to ensure reasonable performances).
+</div>
 
 <img src="/images/sdcard.jpg" width=150><img src="https://yunohost.org/images/micro-sd-card.jpg">
 
-## On Windows
+### With Etcher
 
-* Download and install **[Win32 Disk Imager](http://sourceforge.net/projects/win32diskimager/)**
-* Plug your SD card in
-* Copy the `.img` file to your SD card using Win32 Disk Imager.
+Download <a href="https://etcher.io/" target="_blank">Etcher</a> for your
+operating system and install it.
 
-<img src="/images/win32diskimager.png">
+<img src="/images/etcher.gif">
 
-## On GNU/Linux, BSD or Mac OS
+Plug your SD card, select your YunoHost image and click "Flash"
 
-* Open a terminal
-* Plug your SD card in
-* Identify the device name by typing:
+### With `dd`
 
-```bash
-sudo fdisk -l
-```
-
-It should be `/dev/diskN`, where `N` is a number, or `/dev/sdX`, where `X` is a letter.
-
-Carefull to not put the digit `N` cause it will create an [non-functional SD card](https://raspberrypi.stackexchange.com/questions/11880/sd-card-doesnt-works-after-dd).
-
-* Copy the image by typing:
+If you are on Linux / Mac and know your way around command line, you may also
+flash your SD card with `dd`. You can identify which device corresponds to your
+SD card with `fdisk -l` or `lsblk`. Assuming your SD card is `/dev/mmcblk0` (be
+careful !!), you may run :
 
 ```bash
-sudo dd if=/path/to/your/.img of=/your/device/name
+dd if=/path/to/yunohost.img of=/dev/mmcblk0
 ```
-
-<span class="glyphicon glyphicon-warning-sign"></span> Do not forget to change `/path/to/your/.img` and `/your/device/name` with the appropriate values.
-
-The command may take a few minutes, then your SD card will be ready to use. **:-)**
 
 ## Expand the root partition <small>(optional)</small>
 
+<div class="alert alert-warning" markdown="1">
+This step is optionnal as it should be performed automatically during the first
+boot on recent images.
+</div>
+
 By default, the root partition of your SD card is very small.    
-You can resize it by using software like `resize2fs` (command-line) or `gparted` (graphical).
+You can resize it by using software like `resize2fs` (command-line) or `gparted`
+(graphical).
 
 <img src="/images/gparted.jpg" style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
 

--- a/copy_image_fr.md
+++ b/copy_image_fr.md
@@ -1,45 +1,51 @@
-# Copier l’image sur une carte SD
+# Flasher une carte SD
 
-Maintenant que vous avez l’image ISO YunoHost, vous devez la copier sur une carte SD. Le processus est différent suivant votre système d’exploitation.
+Maintenant que vous avez téléchargé l'image de YunoHost, il vous faut copier son
+contenu sur une carte SD. Cette étape est aussi souvent appelé 'flasher' la
+carte SD.
+
+<div class="alert alert-warning" markdown="1">
+Dans le contexte de l'auto-hébergement, il est recommandé que votre carte SD
+fasse au moins 8 Go (pour disposer d'un espace raisonnable pour le système et
+quelques données) et soit au moins certifiée classe 10 (pour avoir des
+performances raisonnables).
+</div>
 
 <img src="/images/sdcard.jpg" width=150><img src="https://yunohost.org/images/micro-sd-card.jpg">
 
-## Sous Windows
+### Avec Etcher
 
-* Téléchargez et installez **[Win32 Disk Imager](http://sourceforge.net/projects/win32diskimager/)**.
-* Insérez votre carte SD.
-* Copiez le fichier `.img` sur votre carte SD en utilisant *Win32 Disk Imager*.
+Télécharger <a href="https://etcher.io/" target="_blank">Etcher</a> pour votre
+système d'exploitation, et installez-le.
 
-<img src="/images/win32diskimager.png">
+<img src="/images/etcher.gif">
 
-## Sous GNU/Linux, BSD ou Mac OS
+Connectez votre carte SD, sélectionnez votre image YunoHost, puis cliquez sur
+'Flash'.
 
-* Ouvrez un terminal.
-* Insérez votre carte SD.
-* Identifiez votre matériel en tapant :
+### Avec `dd`
 
-```bash
-sudo fdisk -l
-```
-
-Ça devrait être `/dev/diskN`, où `N` est un chiffre, ou `/dev/sdX`, où `X` est une lettre, ou `/dev/mmcblk0`.
-
-Attention à ne pas mettre le chiffre `N` car ça créera une [carte SD non fonctionnelle](https://raspberrypi.stackexchange.com/questions/11880/sd-card-doesnt-works-after-dd).
-
-* Copiez l’image en tapant :
+Si vous êtes sous Linux / Mac et que vous être à l'aise avec la ligne de
+commande, vous pouvez aussi flasher votre carte SD avec `dd`. Commencez par
+identifier le périphérique correspondant à votre carte SD avec `fdisk -l` ou
+`lsblk`. En supposant que votre carte SD soit `/dev/mmcblk0` (faites attention
+!), vous pouvez lancer :
 
 ```bash
-sudo dd if=/chemin/vers/votre/.img of=/nom/du/matériel
+dd if=/chemin/vers/yunohost.img of=/dev/mmcblk0
 ```
 
-<span class="glyphicon glyphicon-warning-sign"></span> N’oubliez pas de changer `/chemin/vers/votre/.img` et `/nom/du/matériel` par les valeurs appropriées.
+## Étendre la partition root <small>(optionnel)</small>
 
-La commande peut prendre quelques minutes, puis votre carte SD sera prête à être utilisée. **:-)**
+<div class="alert alert-warning" markdown="1">
+Cette étape est optionnelle car elle est normalement effectuée automatiquement
+par le système lors du premier démarrage sur les images récentes.
+</div>
 
-## Étendre la partition root <small>(facultatif, mais conseillé)</small>
-
-Par défaut, la partition root installée sur votre carte SD avec la commande `dd` est très petite.   
-Vous pouvez la redimensionner avec un logiciel comme `resize2fs` (ligne de commande) ou `Gparted` (interface graphique) en étendant la partition ext4 au maximum de façon à utiliser tout l’espace non alloué.
+Par défaut, la partition root installée sur votre carte SD avec la commande `dd`
+est très petite.   Vous pouvez la redimensionner avec un logiciel comme
+`resize2fs` (ligne de commande) ou `Gparted` (interface graphique) en étendant
+la partition ext4 au maximum de façon à utiliser tout l’espace non alloué.
 
 <img src="/images/gparted.jpg" style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
 


### PR DESCRIPTION
This is a rework of this page, mainly to advice people to use Etcher which is probably way easier to use than other older tools (or CLI) for newcomers, is OS-agnostic, and ends up being the same as the USB key flashing process.

Also added a small warning that SD card should be at least 8GB and Class 10.

The 'partition resizing' step shouldn't be necessary anymore, as I think it's done automatically at first boot on both RPi and Internet Cube images ?

 