### PR TITLE
Embed the chatroom directly in the help page

### DIFF
--- a/help.md
+++ b/help.md
@@ -9,16 +9,12 @@
 <li><em>Be patient</em>, it can take a few minutes before someone sees your messages.</li>
 </ul>
 </div>
-<strong>Nickname</strong> : <input id="nickname" value="foobar__" type="text">
+
+<iframe src="https://kiwiirc.com/client/irc.freenode.org/?nick=foobar|?&theme=mini#yunohost" style="border:0; width:100%; height:450px;"></iframe>
+
 </br>
 </br>
-<button id="joinChatroom" type="button" class="btn btn-success" style="font-weight:bold;">
-            <span class="glyphicon glyphicon-comment"></span> Join the chatroom
-</button>
-</br>
-</br>
-<em>Note : you can also connect using your favorite XMPP client to </br>
-support@conference.yunohost.org</em>
+<em>Note : this room is also available via XMPP <small>(support@conference.yunohost.org)</small>, or Matrix <small>(#freenode_#yunohost:matrix.org)</small></em>
 </center>
 
 <h3>... or ask on the forum !</h3>
@@ -47,10 +43,7 @@ dev@conference.yunohost.org and apps@conference.yunohost.org</em>
 </center>
 
 <script>
-document.getElementById("joinChatroom").onclick = function() {
-    var nickname = document.getElementById("nickname").value;
-    window.location.href = "https://kiwiirc.com/client/irc.freenode.net/yunohost/?nick="+nickname;
-}
+
 document.getElementById("goForum").onclick = function() {
     var nickname = document.getElementById("nickname").value;
     window.location.href = "https://forum.yunohost.org/latest";

--- a/help_ar.md
+++ b/help_ar.md
@@ -11,12 +11,9 @@
 </div>
 <div dir="rtl"><strong>الإسم المستعار</strong> : <input id="nickname" value="foobar__" type="text">
 </div>
-</br>
-</br>
-<div dir="rtl"><button id="joinChatroom" type="button" class="btn btn-success" style="font-weight:bold;">
-            <span class="glyphicon glyphicon-comment"></span> إنضم إلى غرفة المحادثة
-</button>
-</div>
+
+<iframe src="https://kiwiirc.com/client/irc.freenode.org/?nick=foobar|?&theme=mini#yunohost" style="border:0; width:100%; height:450px;"></iframe>
+
 </br>
 </br>
 <div dir="rtl">
@@ -56,10 +53,6 @@ dev@conference.yunohost.org and apps@conference.yunohost.org</em>
 </center>
 
 <script>
-document.getElementById("joinChatroom").onclick = function() {
-    var nickname = document.getElementById("nickname").value;
-    window.location.href = "https://kiwiirc.com/client/irc.freenode.net/yunohost/?nick="+nickname;
-}
 document.getElementById("goForum").onclick = function() {
     var nickname = document.getElementById("nickname").value;
     window.location.href = "https://forum.yunohost.org/latest";

--- a/help_fr.md
+++ b/help_fr.md
@@ -9,15 +9,14 @@
 <li><em>Soyez patient</em>, cela peut prendre plusieurs minutes avant que quelqu'un remarque vos messages.</li>
 </ul>
 </div>
-<strong>Pseudonyme</strong> : <input id="nickname" value="foobar__" type="text">
+
+<iframe
+src="https://kiwiirc.com/client/irc.freenode.org/?nick=foobar|?&theme=mini#yunohost"
+style="border:0; width:100%; height:450px;"></iframe>
+
 </br>
 </br>
-<button id="joinChatroom" type="button" class="btn btn-success" style="font-weight:bold;">
-            <span class="glyphicon glyphicon-comment"></span> Rejoindre le salon
-</button>
-</br>
-</br>
-<em>Note : vous pouvez aussi vous connecter via votre client XMPP favori à</br>
+<em>Note : ce salon est aussi accessible via XMPP <small>(support@conference.yunohost.org)</small>, ou Matrix <small>(#freenode_#yunohost:matrix.org)</small>.</em>
 support@conference.yunohost.org</em>
 </center>
 
@@ -47,10 +46,6 @@ dev@conference.yunohost.org et apps@conference.yunohost.org</em>
 </center>
 
 <script>
-document.getElementById("joinChatroom").onclick = function() {
-    var nickname = document.getElementById("nickname").value;
-    window.location.href = "https://kiwiirc.com/client/irc.freenode.net/yunohost/?nick="+nickname;
-}
 document.getElementById("goForum").onclick = function() {
     var nickname = document.getElementById("nickname").value;
     window.location.href = "https://forum.yunohost.org/latest";


### PR DESCRIPTION
I don't know what it's worth ... but we were discussing this today during the internet cube meeting, and people think it's pretty fancy to have the chatroom directly integrated in the website as it was before. This is not exactly the same thing (before we had the jappix applet thingy integrated independently of the page) but is similar.

Anyway, here's what it looks like. I don't know if that's the right thing to do, it's open to discussion :wink: 

---

**Upon arriving on the page :** 

![capture du 2018-05-07 21-50-20](https://user-images.githubusercontent.com/4533074/39721881-25393d0a-5241-11e8-8dcc-49e2f76259a2.png)

---

**After clicking Start :** 

![capture du 2018-05-07 21-50-34](https://user-images.githubusercontent.com/4533074/39721886-28ff6fc2-5241-11e8-8564-59def21d25bd.png)
