### PR TITLE
Add a page to list pre-installed images

### DIFF
--- a/images.md
+++ b/images.md
@@ -1,0 +1,114 @@
+# Pre-installed images
+
+<div id="cards-list">
+</div>
+
+<script type="text/template" id="image-template">
+<div id="{id}" class="card panel panel-default">
+        <div class="panel-body text-center">
+            <h3>{name}</h3>
+            <div class="card-comment">{comment}</div>
+            <div class="card-desc text-center">
+<img src="/images/{image}" height=100 style="vertical-align:middle">
+            </div>
+        </div>
+        <div class="annotations">
+            <div class="col-sm-6 annotation"><a href="{file}.sum"><span class="glyphicon glyphicon-barcode" aria-hidden="true"></span> Checksum</a></div>
+            <div class="col-sm-6 annotation"><a href="{file}.sig"><span class="glyphicon glyphicon-tag" aria-hidden="true"></span> Signature</a></div>
+        </div>
+        <div class="btn-group" role="group">
+            <a href="{file}" target="_BLANK" type="button" class="btn btn-info col-sm-12"><span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span> Download <small>{version}</small></a>
+        </div>
+</div>
+</script>
+
+<style>
+/*
+###############################################################################
+  Style sheet for the cards
+###############################################################################
+*/
+#cards-list:after {
+    content:'';
+    display:block;
+    clear: both;
+}
+
+.card {
+    margin-bottom:20px;
+    width:270px;
+    float:left;
+    min-height: 1px;
+    margin-right: 10px;
+    margin-left: 10px;
+}
+
+.card .panel-body >  h3 {
+    margin-top:0;
+    margin-bottom:5px;
+    font-size:1.2em;
+}
+
+.card-desc {
+    height:100px;
+    overflow: hidden;
+}
+
+.card .btn-group {
+    width:100%;
+    margin-left: 0px;
+}
+.card > .btn-group > .btn{
+    border-bottom:0;
+}
+.card > .btn-group {   
+    border-left:0;
+    border-top-left-radius:0;
+    border-top-right-radius:0;
+    margin-left: 0px;
+}
+.card-comment {
+    font-size: 0.8em;
+    margin-top:-5px;
+}
+.card > .annotations {
+    text-align:center;
+    font-size:small;
+}
+</style>
+
+<script>
+/*
+###############################################################################
+  Script that loads the infos from javascript and creates the corresponding
+  cards
+###############################################################################
+*/
+$(document).ready(function () {
+    console.log("in load");
+    $.getJSON('https://build.yunohost.org/images.json', function (images) {
+        $.each(images, function(k, infos) {
+            // Fill the template
+            html = $('#image-template').html()
+             .replace('{id}', infos.id)
+             .replace('{name}', infos.name)
+             .replace('{comment}', infos.comment || "&nbsp;")
+             .replace('{image}', infos.image)
+             .replace('{version}', infos.version);
+ 
+            if (infos.file.startsWith("http"))
+                html = html.replace(/{file}/g, infos.file);
+            else
+                html = html.replace(/{file}/g, "https://build.yunohost.org/"+infos.file);
+   
+            if ((typeof(infos.has_sig_and_sums) !== 'undefined') && infos.has_sig_and_sums == false)
+            {
+                var $html = $(html);
+                $html.find(".annotations").html("&nbsp;");
+                html = $html[0];
+            } 
+            $('#cards-list').append(html);
+        });
+    });
+});
+</script>


### PR DESCRIPTION
So this is an attempt to provide a replacement for the html at build.yunohost.org that list available pre-installed images.

The motivation behind this is that : 
- having yet another individual page not in the "standard" doc is inconsistent in term of UX, and has a maintenance cost
- we now have automatic / semi-automatic image builds and often need to update the links on this page. Currently this is done in a dirty way
- there are plans to produce images for many ARM boards in the mid-term, and it's not trivial to integrate those in the current page

In this proposal, the list of available images is kept in a json here : http://build.yunohost.org/images.json (which can be updated by scripts easily), and "cards" are created in a similar way than the apps page (https://yunohost.org/#/apps)

We get the following : 

![2018-05-08-235553_1366x768_scrot](https://user-images.githubusercontent.com/4533074/39785223-a6cf0aa4-531b-11e8-8934-79ccc659a4fa.png)
