### PR TITLE
Remove / update duplicate postinstall stuff

### DIFF
--- a/boot_and_graphical_install.md
+++ b/boot_and_graphical_install.md
@@ -37,26 +37,16 @@ Check that your computer is physically connected and retry.</div>
 
 * It should reboot automatically.
 
-## <small>4.</small> Proceed to post-installation
+## <small>4.</small> Log in
 
-Once booted, your computer should display a screen like this:
+After the reboot, you should see a black screen with a few words asking you to
+log in. You can log with the following credentials :
 
-<img src="/images/virtualbox_4.png">
+* User: **root**
+* Password: **yunohost**
 
-You can proceed to post-installation right away, or access the **IP** address shown on this screen from another computer's web browser (usually `http://192.168.x.x`)
+## <small>5.</small> Proceed to post-installation
 
-<img src="/images/postinstall_error.png" style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
+<a class="btn btn-lg btn-default" href="/postinstall">Post-install documentation</a>
 
-If you encounter this kind of error, click on "**Proceed**" or "**Add an exception**".    
-This means that you have to trust the certificate which secures your server's connections.    
-Since this is your server, you can bypass it serenely here :-)
 
-<br> 
-
-<img src="/images/postinstall_web.png" style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
-
----
-
-#### More information on the post-installation here:
-
-**[yunohost.org/postinstall](/postinstall)**

--- a/boot_and_graphical_install_fr.md
+++ b/boot_and_graphical_install_fr.md
@@ -35,26 +35,16 @@ Vérifiez que votre serveur est bien branché et réessayez.</div>
 
 * L’ordinateur devrait redémarrer automatiquement à la fin de l’installation.
 
-## <small>4.</small> Procéder à la post-installation
+## <small>4.</small> Log in
 
-Une fois démarré, votre serveur devrait afficher un écran comme celui-ci :
+Après avoir redémarrer, votre machine devrait afficher un écran noir avec
+quelques mots vous invitant à vous identifier. Vous pouvez utiliser les
+identifiants suivants :
 
-<img src="/images/virtualbox_4.png">
+* User: **root**
+* Password: **yunohost**
 
-Vous pouvez procéder à la post-installation directement, ou accéder à l’adresse **IP** affichée sur cet écran depuis un navigateur web d’un autre ordinateur (généralement `http://192.168.x.x`)
+## <small>5.</small> Procéder à la post-installation
 
-<img src="/images/postinstall_error.png" style="max-width:100% ; border-radius: 5px ; border: 1px solid rgba(0,0,0,0.15) ; box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
+<a class="btn btn-lg btn-default" href="/postinstall_fr">Documentation de la post-installation</a>
 
-Si vous rencontrez une erreur de ce type, cliquez sur « **Poursuivre quand même** » ou « **Ajouter une exception** ».
-Cela signifie que vous devez faire confiance au certificat qui sécurise les connexions avec votre serveur.    
-Comme c’est le votre, vous pouvez le valider sereinement ici :-). (Certains navigateurs interdisent totalement la connexion. Si c'est le cas, vous pouvez réessayer avec un autre.)
-
-<br>
-
-<img src="/images/postinstall_web.png" style="max-width:100% ; border-radius: 5px ; border: 1px solid rgba(0,0,0,0.15) ; box-shadow: 0 5px 15px rgba(0,0,0,0.35);">
-
----
-
-#### Plus d’informations sur la post-installation ici :
-
-**[yunohost.org/postinstall](/postinstall)**


### PR DESCRIPTION
This page https://yunohost.org/#/boot_and_graphical_install contains some info about the postinstall, which is a duplicate not up to date of https://yunohost.org/#/postinstall ...

Also it does not explain what are the credentials to log in