### PR TITLE
Update security doc -- fail2ban SSH port config

### DIFF
--- a/security.md
+++ b/security.md
@@ -77,6 +77,31 @@ yunohost firewall reload
 yunohost firewall disallow <your_old_ssh_port_number> # port by default 22
 ``` 
 
+You also need to give fail2ban the new SSH port.
+
+To do that you need to create the configuration file `my_ssh_port.conf` with the command
+
+
+```bash
+nano /etc/fail2ban/jail.d/my_ssh_port.conf
+``` 
+
+and you can fill it with
+
+```
+[sshd]
+port = <votre_numero_de_port_ssh>
+
+[sshd-ddos]
+port = <votre_numero_de_port_ssh>
+```
+
+Finally you have to restart fail2ban in order to apply the new configuration
+
+```bash
+systemctl restart fail2ban.service
+``` 
+
 **For the next SSH connections ** you need to add the `-p` option followed by the SSH port number.
 
 **Sample**:

--- a/security_fr.md
+++ b/security_fr.md
@@ -91,6 +91,30 @@ yunohost firewall reload
 yunohost firewall disallow TCP <votre numéro de port> # port par défaut 22
 ``` 
 
+Il convient également de donner à fail2ban le nouveau port SSH à bloquer en cas de bannissement d'une adresse IP.
+
+Pour cela il suffit de créer le fichier de configuration `my_ssh_port.conf` avec
+
+```bash
+nano /etc/fail2ban/jail.d/my_ssh_port.conf
+``` 
+
+et de le compléter ainsi :
+
+```
+[sshd]
+port = <votre_numero_de_port_ssh>
+
+[sshd-ddos]
+port = <votre_numero_de_port_ssh>
+```
+
+Il reste enfin à relancer fail2ban pour prendre en compte la nouvelle configuration 
+
+```bash
+systemctl restart fail2ban.service
+``` 
+
 **Pour les prochaines connexions SSH** il faudra ajouter l’option -p suivie du numéro de port SSH.
 
 **Exemple** :


### PR DESCRIPTION
Quand on modifie le port SSH par défaut je pense qu'il faut aussi donner ce nouveau port à fail2ban pour qu'il créé la bonne règle iptables an cas de bannissement.

Peut être à reprendre légèrement ?