### PR TITLE
Improve postinstall doc, in particular regarding the initial certificate warning

### DIFF
--- a/postinstall.md
+++ b/postinstall.md
@@ -2,17 +2,23 @@
 
 The step called "**post-installation**" is actually the initial configuration of YunoHost. It has to be done just after the installation of the system itself.
 
-## Access
+### From the web interface
 
-You can access it graphically by entering your **server's local IP** address in a **web browser** (e.g. `192.168.x.x`, see ['Find your IP' on the page about SSH](/ssh))
+You can perform the post-installation with the web interface by entering in your browser :
+* **the local IP address of your server** if it is on your local network (e.g. at home !). The address typically looks like `192.168.x.y` (see 'Find your IP' on [the page about SSH](/ssh))
+* **the public IP address of your server** if your server is not on your local network. Typically, if you own a VPS, your VPS provider should have gave you the IP of the server.
+
+During the first visit, you will very likely encounter a security warning related to the certificate used by the server. For now, your server uses a self-signed certificate. You will later be able to add a certificate automatically recognized by web browsers as described in the [certificate documentation](/certificate). For now, you should add a security exception to accept the current certificate.
+
+You should then land on this page :
 
 <img style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);" src="/images/postinstall_web.png">
 
 <em><p class="text-muted">Preview of the Web post-installation</p></em>
 
-<br>
+### From the command line
 
-Or by running `yunohost tools postinstall` in command-line.
+You can also perform the postinstallation with the command `yunohost tools postinstall` directly on the server, or [via SSH](/ssh).
 
 <img style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);" src="/images/postinstall_cli.png">
 
@@ -20,7 +26,7 @@ Or by running `yunohost tools postinstall` in command-line.
 
 <br>
 
----
+## Informations asked
 
 ### Main domain
 

--- a/postinstall_fr.md
+++ b/postinstall_fr.md
@@ -3,27 +3,29 @@
 
 L’étape appelée « **post-installation** » est en fait l’étape de configuration initiale de YunoHost. Il faut l’exécuter après l’**installation** du système en lui-même.
 
-## Accès
+### Via l'interface web
 
 Vous pouvez accéder à la post-installation graphique en entrant dans un navigateur web :
 * l’adresse **IP locale de votre serveur** si celui-ci est connecté à votre réseau local (généralement `192.168.x.x`, voir ['Trouver son IP' sur la page sur SSH](/ssh))
-* l’adresse **IP publique de votre serveur** si celui-ci n’est pas connecté à votre réseau local.
+* l’adresse **IP publique de votre serveur** si celui-ci n’est pas connecté à votre réseau local (par exemple dans le cas d'un VPS, votre fournisseur devrait vous avoir transmis l'adresse IP).
+
+Lors de la première visite, vous rencontrerez très probablement un avertissement de sécurité lié au certificat utilisé. Pour le moment, votre serveur utilise un certificat auto-signé. Vous pourrez plus tard ajouter un certificat automatiquement reconnus par les navigateurs comme décrit dans la page sur les [Certificats](/certificate). En attendant, ajoutez une exception de sécurité pour accepter le certificat actuel.
+
+Vous arrivez ensuite sur cette page :
 
 <img style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);" src="/images/postinstall_web.png">
 
 *<p class="text-muted">Aperçu de la post-installation Web</p>*
 
-<br>
+### Via la ligne de commande
 
-Vous pouvez aussi y accéder en entrant la commande `yunohost tools postinstall` directement sur le serveur ou en SSH.
+Vous pouvez aussi y accéder en entrant la commande `yunohost tools postinstall` directement sur le serveur ou [en SSH](/ssh).
 
 <img style="max-width:100%;border-radius: 5px;border: 1px solid rgba(0,0,0,0.15);box-shadow: 0 5px 15px rgba(0,0,0,0.35);" src="/images/postinstall_cli.png">
 
 *<p class="text-muted">Aperçu de la post-installation en ligne de commande</p>*
 
-<br>
-
----
+## Informations demandées
 
 ### Domaine principal
 


### PR DESCRIPTION
Currently the postinstall doc doesn't say anything about the security warning one might encounter when running the postinstall from the web browser... This fixes it.

Also included a few cosmetics adjustments

