### PR TITLE
Remove ipv6 talk page...

### DIFF
--- a/ipv6_fr.md
+++ b/ipv6_fr.md
@@ -1,7 +1,0 @@
-# IPv6 <img src="/images/ipv6.png" width=40>
-
-### Liens
-
-- [Conférence — (Introduction à) IPv6 — Stéphane Bortzmeyer — Liens en bas](https://fr33tux.org/post/retour-conference-bortzmeyer/#Liens)
-- [Conférence — Intranet IPv4 ou Internet IPv6 — Julien Vaubourg](http://julien.vaubourg.com/#videos)
-- [Article de blog — Auto-hébergement IPv6, le soucis de NAT — Genma](http://genma.free.fr/?Autohebergement-IPV6-Le-soucis-du-NAT)


### PR DESCRIPTION
Dunno what to do with this either ... to me it's out of scope of this documentation as there's nothing related to yunohost on this page, those are just random talks about ipv6 (which of course should be encouraged somehow but this page is not linked anywhere in the documentation :|)