### PR TITLE
backup_core_only option for nextcloud

### DIFF
--- a/backup_fr.md
+++ b/backup_fr.md
@@ -54,7 +54,7 @@ Pour plus d'informations et d'options sur la création d'archives, consultez `yu
 
 #### Configuration spécifique à certaines apps
 
-Certaines apps comme Nextcloud sont potentiellement rattachées à des quantités importantes de données, qui ne sont pas sauvegardées par défaut. Dans ce cas, on dit que l'app "sauvegarde uniquement le core" (de l'app). Néanmoins, il est possible d'activer la sauvegarde de toutes les données de cette application avec (dans le cas de Nextcloud) `yunohost app setting nextcloud backup_core_only -v 0`. Soyez prudent : en fonction des données stockées dans Nextcloud, il se peut que l'archive que vous obtenez ensuite devienne énorme...
+Certaines apps comme Nextcloud sont potentiellement rattachées à des quantités importantes de données, qui ne sont pas sauvegardées par défaut. Dans ce cas, on dit que l'app "sauvegarde uniquement le core" (de l'app). Néanmoins, il est possible d'activer la sauvegarde de toutes les données de cette application avec (dans le cas de Nextcloud) `yunohost app setting nextcloud backup_core_only -v ''`. Soyez prudent : en fonction des données stockées dans Nextcloud, il se peut que l'archive que vous obtenez ensuite devienne énorme...
 
 Télécharger et téléverser des sauvegardes
 -----------------------------------------


### PR DESCRIPTION
I have been trying to backup nextcloud with "backup_core_only -v 0" but it didn't work until i found a wiki somewhere on the internet which mentions "backup_core_only -v ''" and my data backup worked only since.
I hope it helps.