### PR TITLE
Update packaging_apps_levels.md

### DIFF
--- a/packaging_apps_levels.md
+++ b/packaging_apps_levels.md
@@ -23,22 +23,22 @@ The application installs and uninstalls correctly in all common configurations.
 The application can be updated.
 
 **Level 4**
-The application uses YunoHost users directly and allows unique identification from the YunoHost portal.
+The application can be saved and restored.
 
 **Level 5**
 The application package code follows some syntax rules.
 
 **Level 6**
-The application can be saved and restored.
+The application package is in the YunoHost-Apps organization.
 
 **Level 7**
 The application package passes all integrity tests successfully.
 
 **Level 8**
-The application respects a set of advanced recommendations improving its general quality.
+The application package respects all packaging recommendations. This is a high quality app.
 
 **Level 9**
-The application complies with all recommendations. This is an excellent quality package.
+The application complies with higher packaging recommendations. Not available yet.
 
 **Level 10**
 The application package is considered perfect!
@@ -88,7 +88,6 @@ YEP to be respected to reach level 2:
 - *[YEP 2.18.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-2184---supporter-linstallation-sur-un-sous-dossier----valid%C3%A9--auto--official-) : Support installation on a subfolder*
 - *[YEP 4.6](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-46---g%C3%A8re-le-multi-instance----valid%C3%A9--manuel--optional-) : Manage multi-instance*
 
-
 ### Level 3
 
 **The application supports upgrade from an older version of the package.**  
@@ -100,16 +99,11 @@ YEP to be respected to reach level 3:
 
 ### Level 4
 
-**The application supports LDAP and HTTP AUTH**
-
-The application manages its users directly from the [YunoHost ldap base](https://github.com/YunoHost/SSOwat/blob/366dd6c4438e6550f7438c36893690b628340185/config.lua#L50-L53) and allows unified connection using [HTTP authentication](https://fr.wikipedia.org/wiki/Authentification_HTTP) from the SSO.
-
-*If the application is not capable of supporting an ldap directory or HTTP authentication, this level can be ignored.  *
-*However, it is necessary to be able to justify this impossibility*.
+**The application can be backed up and restored without error on the same machine or another.** 
 
 YEP to be respected to reach level 4:
-- *[YEP 4.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-41---lier-au-ldap----valid%C3%A9--manuel--official-) : Link to ldap*
-- *[YEP 4.2](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-42---lier-lauthentification-au-sso----valid%C3%A9--manuel--official-) : Bind authentication to sso*
+- *[YEP 4.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-43---fournir-un-script-de-sauvegarde-yunohost-fonctionnel----valid%C3%A9--auto--official-) : Provide a functional YunoHost backup script*
+- *[YEP 4.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-44---fournir-un-script-de-restauration-yunohost-fonctionnel----valid%C3%A9--auto--official-) :  Provide a functional YunoHost restore script*
 
 ### Level 5
 
@@ -119,10 +113,9 @@ YEP to be respected to reach level 4:
 
 YEP to be respected to reach level 5:
 - *[YEP 1.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-13---indiquer-la-licence-associ%C3%A9e-au-paquet---valid%C3%A9--auto--working-) : Specify the license associated with the package*
-- [YEP 2.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-21---respecter-le-format-du-manifeste---valid%C3%A9--auto--inprogress-) : Respect manifest format
+- *[YEP 2.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-21---respecter-le-format-du-manifeste---valid%C3%A9--auto--inprogress-) : Respect manifest format*
 - [YEP 2.12](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-212---utiliser-les-commandes-pratiques-helpers---valid%C3%A9--auto--official-) : Use practical commands (helpers)
 - [YEP 2.18.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-2181---lancer-le-script-dinstallation-dune-webapp-correctement----valid%C3%A9--manuel--working-) : Run the webapp installation script correctly
-
 
 ### Level 6
 
@@ -131,7 +124,7 @@ YEP to be respected to reach level 5:
 YEP to be respected to reach level 6:
 - [YEP 1.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-14---informer-sur-lintention-de-maintenir-un-paquet----brouillon--manuel--working-) : Inform about the intention to maintain a package
 - [YEP 1.6](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-16---se-tenir-inform%C3%A9-sur-l%C3%A9volution-du-packaging-dapps---valid%C3%A9--manuel--official-) : As a maintainer, keep checking and being aware of the evolution of apps packaging
-- [YEP 1.7](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-17---ajouter-lapp-%C3%A0-lorganisation-yunohost-apps---valid%C3%A9--manuel--official-) : Add app to the [YunoHost-Apps organization](https://github.com/YunoHost-Apps)
+- *[YEP 1.7](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-17---ajouter-lapp-%C3%A0-lorganisation-yunohost-apps---valid%C3%A9--manuel--official-) : Add app to the [YunoHost-Apps organization](https://github.com/YunoHost-Apps)*
 - [YEP 1.8](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-18---publier-des-demandes-de-test---valid%C3%A9--manuel--official-) : Publish test requests
 - [YEP 1.9](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-19---documenter-lapp---valid%C3%A9--auto--official-) : Document app
 - [YEP 1.10](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-110---garder-un-historique-de-version-propre----brouillon--manuel--official-) : Keep a clean version history
@@ -139,10 +132,6 @@ YEP to be respected to reach level 6:
 - [YEP 3.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-33---faciliter-le-contr%C3%B4le-de-lint%C3%A9grit%C3%A9-des-sources----brouillon--manuel--official-) :  Facilitating source integrity control
 - [YEP 3.5](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-35---suivre-les-recommendations-de-la-documentation-de-lapp----valid%C3%A9--manuel--official-) : Follow the recommendations of the app documentation
 - [YEP 3.6](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-36---mettre-%C3%A0-jour-les-versions-contenant-des-cve----draft--manuel--official-) : Update versions containing CVEs
-- *[YEP 4.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-43---fournir-un-script-de-sauvegarde-yunohost-fonctionnel----valid%C3%A9--auto--official-) : Provide a functional YunoHost backup script*
-- *[YEP 4.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-44---fournir-un-script-de-restauration-yunohost-fonctionnel----valid%C3%A9--auto--official-) :  Provide a functional YunoHost restore script*
-
-If an app reaches level 6, it may qualify to join the official applications.
 
 ### Level 7
 
@@ -151,20 +140,23 @@ If an app reaches level 6, it may qualify to join the official applications.
 Considering the maximum number of tests possible for the application.
 
 YEP à respecter pour atteindre le niveau 7:
+- [YEP 2.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-24---d%C3%A9tecter-et-g%C3%A9rer-les-erreurs---brouillon--manuel--working-) : Error detection and management
 - [YEP 2.6](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-26---annuler-laction-si-les-valeurs-dentr%C3%A9es-sont-incorrectes----valid%C3%A9--manuel--working-) :  Cancel action if input values are incorrect
+- [YEP 2.8](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-28---modifier-correctement-une-configuration-syst%C3%A8me----brouillon--manuel--working-) : Change a system configuration correctly
+- [YEP 2.10](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-210---configurer-les-logs-de-lapplication----brouillon--manuel--working-) : Configure application logs
+- [YEP 2.11](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-211---utiliser-une-variable-plut%C3%B4t-que-lapp-id-directement---valid%C3%A9--manuel--official-) : Use a variable rather than the app id directly
+- [YEP 2.13](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-213---traduire-le-package-en-anglais----brouillon--manuel--official-) : Translate the package into English
 - [YEP 3.2](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-32---ouvrir-un-port-correctement----brouillon--manuel--working-) : Open port: Open port correctly
-
 
 ### Level 8
 
-**The application complies with all recommended YEPs.**
+**The application package respects all packaging recommendations. This is a high quality app.**
 
 YEP to be respected to reach level 8:
-- [YEP 2.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-24---d%C3%A9tecter-et-g%C3%A9rer-les-erreurs---brouillon--manuel--working-) : Error detection and management
-- [YEP 2.8](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-28---modifier-correctement-une-configuration-syst%C3%A8me----brouillon--manuel--working-) : Change a system configuration correctly
-- [YEP 2.16](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-216---v%C3%A9rifier-la-disponibilit%C3%A9-des-d%C3%A9pendances-sur-arm-x86-et-x64----valid%C3%A9--manuel--official-) : Check dependency availability on ARM, x86 and x64
+- *[YEP 2.16](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-216---v%C3%A9rifier-la-disponibilit%C3%A9-des-d%C3%A9pendances-sur-arm-x86-et-x64----valid%C3%A9--manuel--official-) : Check dependency availability on ARM, x86 and x64*
 - [YEP 2.18.5](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-2185---ajouter-la-tuile-yunohost-pour-naviguer-facilement-entre-les-applications----valid%C3%A9--manuel--official-) : Add the YunoHost tile to easily navigate between applications
-- [YEP 3.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-34---isoler-lapp----brouillon--manuel--official-) : Isolate app
+- [YEP 4.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-41---lier-au-ldap----valid%C3%A9--manuel--official-) : Link to ldap
+- [YEP 4.2](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-42---lier-lauthentification-au-sso----valid%C3%A9--manuel--official-) : Bind authentication to sso
 - [YEP 4.5](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-45---utiliser-les-hooks----valid%C3%A9--manuel--optional-) : Use hooks
 
 If an application is not available on an architecture, and it is impossible to circumvent this limitation reasonably, this limitation must be indicated in the REDME and taken into account in the installation script. The installation of the application on an unsupported architecture must be stopped before modifying the filesystem.
@@ -175,32 +167,13 @@ If an application is not available on an architecture, and it is impossible to c
 
 YEP to be respected to reach level 9:
 
-- [YEP 2.10](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-210---configurer-les-logs-de-lapplication----brouillon--manuel--working-) : Configure application logs
-- [YEP 2.11](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-211---utiliser-une-variable-plut%C3%B4t-que-lapp-id-directement---valid%C3%A9--manuel--official-) : Use a variable rather than the app id directly
-- [YEP 2.13](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-213---traduire-le-package-en-anglais----brouillon--manuel--official-) : Translate the package into English
 - [YEP 2.14](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-214---remplir-correctement-un-fichier-de-conf----brouillon--manuel--official-) :  Fill a conf file correctly
 - [YEP 2.17](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-217---prendre-en-compte-la-version-dorigine-lors-des-mises-%C3%A0-jour----valid%C3%A9--manuel--official-) : Take into account the original version during updates
+- [YEP 3.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-34---isoler-lapp----brouillon--manuel--official-) : Isolate app
 - [YEP 4.2.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-421---d%C3%A9connexion----valid%C3%A9--manuel--official-) : Logout
-
 
 ### Level 10
 
 **The application is considered perfect.**
 
 This ultimate level for an application can only be reached after an in-depth study of the package and by the validation of the Apps group.
-
-
-## How to request the integration of an application in the official list?
-
-Before requesting an application for inclusion in the official list, you must commit to maintaining the application over time, or find someone who will commit to doing so.  
-An official application must be regularly updated and follow packaging recommendations as closely as possible.
-
-To be eligible to join the official list, the application must have reached at least level 6 and must be free software.
-
-If all these requirements are met, you can create a pull request on the official list or make a request on the forum.  
-From then on, the package will be checked by Apps group members and the decision to include it in the list of official applications will be discussed by the group.  
-Hopefully the application will join the official YunoHost applications.
-
-
-
-

--- a/packaging_apps_levels.md
+++ b/packaging_apps_levels.md
@@ -153,6 +153,7 @@ YEP à respecter pour atteindre le niveau 7:
 **The application package respects all packaging recommendations. This is a high quality app.**
 
 YEP to be respected to reach level 8:
+- [YEP 1.12](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-112) : Follow the template from example_ynh
 - *[YEP 2.16](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-216---v%C3%A9rifier-la-disponibilit%C3%A9-des-d%C3%A9pendances-sur-arm-x86-et-x64----valid%C3%A9--manuel--official-) : Check dependency availability on ARM, x86 and x64*
 - [YEP 2.18.5](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-2185---ajouter-la-tuile-yunohost-pour-naviguer-facilement-entre-les-applications----valid%C3%A9--manuel--official-) : Add the YunoHost tile to easily navigate between applications
 - [YEP 4.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-41---lier-au-ldap----valid%C3%A9--manuel--official-) : Link to ldap

--- a/packaging_apps_levels_fr.md
+++ b/packaging_apps_levels_fr.md
@@ -23,22 +23,22 @@ L'application s'installe et se désinstalle correctement dans toutes les configu
 L'application peut être mise à jour.
 
 **Niveau 4**  
-L'application utilise directement les utilisateurs YunoHost et permet l'identification unique à partir du portail YunoHost.
+L'application peut-être sauvegardée et restaurée.
 
 **Niveau 5**  
 Le code du package d'application respecte certaines règles de syntaxe.
 
 **Niveau 6**  
-L'application peut-être sauvegardée et restaurée.
+Le package d'application est dans l'organisation YunoHost-Apps.
 
 **Niveau 7**  
 Le package d'application passe avec succès l'ensemble des tests d'intégrité.
 
 **Niveau 8**  
-L'application respecte un ensemble de recommandations avancées améliorant sa qualité générale.
+Le package d'application respecte toute les recommendations de packaging d'apps. C'est une app de très bonne qualité.
 
 **Niveau 9**  
-L'application respecte toutes les recommandations. C'est un package d'excellente qualité.
+Le package d'application respecte des recommandations de packaging supérieures. Non disponible pour le moment.
 
 **Niveau 10**  
 Le package d'application est jugé parfait !
@@ -91,15 +91,11 @@ YEP à respecter pour atteindre le niveau 3:
 - [YEP 2.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-23---sauvegarder-les-r%C3%A9ponses-lors-de-linstallation---valid%C3%A9--manuel--working-) : Sauvegarder les réponses lors de l'installation
 
 ### Niveau 4
-**L'application prend en charge ldap et HTTP AUTH**  
-L'application gère ses utilisateurs directement à partir de la [base ldap de YunoHost](https://github.com/YunoHost/SSOwat/blob/366dd6c4438e6550f7438c36893690b628340185/config.lua#L50-L53) et permet la connexion unifiée en utilisant l'[authentification HTTP](https://fr.wikipedia.org/wiki/Authentification_HTTP) depuis le SSO.
-
-*Si l'application n'est pas capable de prendre en charge un annuaire ldap ou l'authentification HTTP, ce niveau peut être ignoré.*  
-*Il faut toutefois être en mesure de justifier de cette impossibilité*
+**L'application peut-être sauvegardée et restaurée sans erreur sur la même machine ou une autre.**  
 
 YEP à respecter pour atteindre le niveau 4:
-- *[YEP 4.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-41---lier-au-ldap----valid%C3%A9--manuel--official-) : Lier au ldap*
-- *[YEP 4.2](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-42---lier-lauthentification-au-sso----valid%C3%A9--manuel--official-) : Lier l'authentification au sso*
+- *[YEP 4.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-43---fournir-un-script-de-sauvegarde-yunohost-fonctionnel----valid%C3%A9--auto--official-) : Fournir un script de sauvegarde YunoHost fonctionnel*
+- *[YEP 4.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-44---fournir-un-script-de-restauration-yunohost-fonctionnel----valid%C3%A9--auto--official-) : Fournir un script de restauration YunoHost fonctionnel*
 
 ### Niveau 5
 **L'application ne présente aucune erreur dans [Package linter](https://github.com/YunoHost/package_linter).**  
@@ -107,17 +103,17 @@ YEP à respecter pour atteindre le niveau 4:
 
 YEP à respecter pour atteindre le niveau 5:
 - *[YEP 1.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-13---indiquer-la-licence-associ%C3%A9e-au-paquet---valid%C3%A9--auto--working-) : Indiquer la licence associée au paquet*
-- [YEP 2.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-21---respecter-le-format-du-manifeste---valid%C3%A9--auto--inprogress-) : Respecter le format du manifeste
+- *[YEP 2.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-21---respecter-le-format-du-manifeste---valid%C3%A9--auto--inprogress-) : Respecter le format du manifeste*
 - [YEP 2.12](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-212---utiliser-les-commandes-pratiques-helpers---valid%C3%A9--auto--official-) : Utiliser les commandes pratiques (helpers)
 - [YEP 2.18.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-2181---lancer-le-script-dinstallation-dune-webapp-correctement----valid%C3%A9--manuel--working-) : Lancer le script d'installation d'une webapp correctement
 
 ### Niveau 6
-**L'application peut-être sauvegardée et restaurée sans erreur sur la même machine ou une autre.**  
+**Le package d'application est dans l'organisation YunoHost-Apps.**  
 
 YEP à respecter pour atteindre le niveau 6:
 - [YEP 1.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-14---informer-sur-lintention-de-maintenir-un-paquet----brouillon--manuel--working-) : Informer sur l'intention de maintenir un paquet
 - [YEP 1.6](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-16---se-tenir-inform%C3%A9-sur-l%C3%A9volution-du-packaging-dapps---valid%C3%A9--manuel--official-) : Se tenir informé sur l'évolution du packaging d'apps
-- [YEP 1.7](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-17---ajouter-lapp-%C3%A0-lorganisation-yunohost-apps---valid%C3%A9--manuel--official-) : Ajouter l'app à l'[organisation YunoHost-Apps](https://github.com/YunoHost-Apps)
+- *[YEP 1.7](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-17---ajouter-lapp-%C3%A0-lorganisation-yunohost-apps---valid%C3%A9--manuel--official-) : Ajouter l'app à l'[organisation YunoHost-Apps](https://github.com/YunoHost-Apps)*
 - [YEP 1.8](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-18---publier-des-demandes-de-test---valid%C3%A9--manuel--official-) : Publier des demandes de test
 - [YEP 1.9](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-19---documenter-lapp---valid%C3%A9--auto--official-) : Documenter l'app
 - [YEP 1.10](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-110---garder-un-historique-de-version-propre----brouillon--manuel--official-) : Garder un historique de version propre
@@ -125,28 +121,28 @@ YEP à respecter pour atteindre le niveau 6:
 - [YEP 3.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-33---faciliter-le-contr%C3%B4le-de-lint%C3%A9grit%C3%A9-des-sources----brouillon--manuel--official-) : Faciliter le contrôle de l'intégrité des sources
 - [YEP 3.5](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-35---suivre-les-recommendations-de-la-documentation-de-lapp----valid%C3%A9--manuel--official-) : Suivre les recommandations de la documentation de l'app
 - [YEP 3.6](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-36---mettre-%C3%A0-jour-les-versions-contenant-des-cve----draft--manuel--official-) : Mettre à jour les versions contenant des CVE
-- *[YEP 4.3](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-43---fournir-un-script-de-sauvegarde-yunohost-fonctionnel----valid%C3%A9--auto--official-) : Fournir un script de sauvegarde YunoHost fonctionnel*
-- *[YEP 4.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-44---fournir-un-script-de-restauration-yunohost-fonctionnel----valid%C3%A9--auto--official-) : Fournir un script de restauration YunoHost fonctionnel*
-
-**Si une app atteint le niveau 6, elle peut prétendre à rejoindre les applications officielles.**
 
 ### Niveau 7
 **L'application ne présente aucune erreur dans [Package check](https://github.com/YunoHost/package_check).**  
 En considérant le maximum de tests possibles pour l'application.
 
 YEP à respecter pour atteindre le niveau 7:
+- [YEP 2.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-24---d%C3%A9tecter-et-g%C3%A9rer-les-erreurs---brouillon--manuel--working-) : Détecter et gérer les erreurs
 - [YEP 2.6](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-26---annuler-laction-si-les-valeurs-dentr%C3%A9es-sont-incorrectes----valid%C3%A9--manuel--working-) : Annuler l'action si les valeurs d'entrées sont incorrectes
+- [YEP 2.8](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-28---modifier-correctement-une-configuration-syst%C3%A8me----brouillon--manuel--working-) : Modifier correctement une configuration système
+- [YEP 2.10](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-210---configurer-les-logs-de-lapplication----brouillon--manuel--working-) : Configurer les logs de l'application
+- [YEP 2.11](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-211---utiliser-une-variable-plut%C3%B4t-que-lapp-id-directement---valid%C3%A9--manuel--official-) : Utiliser une variable plutôt que l'app id directement
+- [YEP 2.13](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-213---traduire-le-package-en-anglais----brouillon--manuel--official-) : Traduire le package en anglais
 - [YEP 3.2](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-32---ouvrir-un-port-correctement----brouillon--manuel--working-) : Ouvrir un port correctement
 
 ### Niveau 8
-**L'application respecte toutes les YEP recommandées.**
+**Le package d'application respecte toute les recommendations de packaging d'apps. C'est une app de très bonne qualité.**
 
 YEP à respecter pour atteindre le niveau 8:
-- [YEP 2.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-24---d%C3%A9tecter-et-g%C3%A9rer-les-erreurs---brouillon--manuel--working-) : Détecter et gérer les erreurs
-- [YEP 2.8](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-28---modifier-correctement-une-configuration-syst%C3%A8me----brouillon--manuel--working-) : Modifier correctement une configuration système
-- [YEP 2.16](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-216---v%C3%A9rifier-la-disponibilit%C3%A9-des-d%C3%A9pendances-sur-arm-x86-et-x64----valid%C3%A9--manuel--official-) : Vérifier la disponibilité des dépendances sur ARM, x86 et x64
+- *[YEP 2.16](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-216---v%C3%A9rifier-la-disponibilit%C3%A9-des-d%C3%A9pendances-sur-arm-x86-et-x64----valid%C3%A9--manuel--official-) : Vérifier la disponibilité des dépendances sur ARM, x86 et x64*
 - [YEP 2.18.5](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-2185---ajouter-la-tuile-yunohost-pour-naviguer-facilement-entre-les-applications----valid%C3%A9--manuel--official-) : Ajouter la tuile YunoHost pour naviguer facilement entre les applications
-- [YEP 3.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-34---isoler-lapp----brouillon--manuel--official-) : Isoler l'app
+- [YEP 4.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-41---lier-au-ldap----valid%C3%A9--manuel--official-) : Lier au ldap
+- [YEP 4.2](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-42---lier-lauthentification-au-sso----valid%C3%A9--manuel--official-) : Lier l'authentification au sso
 - [YEP 4.5](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-45---utiliser-les-hooks----valid%C3%A9--manuel--optional-) : Utiliser les hooks
 
 *Si une application n'est pas disponible sur une architecture, et qu'il est impossible de contourner cette limitation raisonnablement, cette limitation doit être indiquée dans le readme et prise en compte dans le script d'installation. L'installation de l'application sur une architecture non supportée doit être stoppée avant de modifier les fichiers.*
@@ -155,27 +151,11 @@ YEP à respecter pour atteindre le niveau 8:
 **L'application respecte toutes les YEP optionnelles.**
 
 YEP à respecter pour atteindre le niveau 9:
-- [YEP 2.10](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-210---configurer-les-logs-de-lapplication----brouillon--manuel--working-) : Configurer les logs de l'application
-- [YEP 2.11](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-211---utiliser-une-variable-plut%C3%B4t-que-lapp-id-directement---valid%C3%A9--manuel--official-) : Utiliser une variable plutôt que l'app id directement
-- [YEP 2.13](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-213---traduire-le-package-en-anglais----brouillon--manuel--official-) : Traduire le package en anglais
 - [YEP 2.14](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-214---remplir-correctement-un-fichier-de-conf----brouillon--manuel--official-) : Remplir correctement un fichier de conf
 - [YEP 2.17](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-217---prendre-en-compte-la-version-dorigine-lors-des-mises-%C3%A0-jour----valid%C3%A9--manuel--official-) : Prendre en compte la version d'origine lors des mises à jour
+- [YEP 3.4](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-34---isoler-lapp----brouillon--manuel--official-) : Isoler l'app
 - [YEP 4.2.1](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines_fr.md#yep-421---d%C3%A9connexion----valid%C3%A9--manuel--official-) : Déconnexion
 
 ### Niveau 10
 **L'application est jugée parfaite !**  
 Ce niveau ultime pour une application ne peux être atteint que suite à étude approfondie du package et par la validation du groupe Apps.
-
-
-## Comment demander l'intégration d'une application dans la liste officielle ?
-
-Avant de demander l'intégration d'une application dans la liste officielle, vous devez vous engager à maintenir l'application sur la durée, ou trouver quelqu'un qui s'engage à le faire.  
-Une application officielle doit être régulièrement mise à jour et suivre au mieux les recommandations de packaging.
-
-Pour prétendre à rejoindre la liste officielle, l'application doit avoir atteint au moins le niveau 6 et doit être un logiciel libre.
-
-Si tout ces prérequis sont satisfaits, vous pouvez créer une pull request sur la liste officielle ou faire une demande sur le forum.  
-Dés lors, le package sera vérifié par les membres du groupe Apps et la décision de l'inclure dans la liste des applications officielles sera débattue par le groupe.  
-Si tout va bien l'application rejoindra les applications officielles de YunoHost.
-
-


### PR DESCRIPTION
According to our discussion during the last meeting.
We would like to use the level 8 for high quality packages.

So I made a little refactoring of the levels. Also I change the level 4, which is quite complicated to handle and not really representative of the real level of an app.

To explain my modifications:
- The level 4 is now about how the app handles backup and restore. It's a must have now.
- While the level 6 is, for the automatic part with Package_check, is only about the app being in YunoHost-Apps.
Not that much, but didn't find anything else we could check automatically without changing all levels.
And anyway, nowadays, we're much about very low level (1-3) and level 7.
- Level 7 gets many YEP that were in level 8 and 9, but actually already expected for a level 7 app.
- Level 8 gets ldap and SSO. Since we can't check that automatically.
- Level 9 gets app isolation. We don't know yet how to do that properly for most of our apps

The level 8 would be now a manual level (Accorded only by Apps group) about high quality apps that respect all packaging recommendations.

Related to https://github.com/YunoHost/apps/pull/677

**This PR should be merged after https://github.com/YunoHost/doc/pull/935**