### PR TITLE
Update app_nextcloud_fr.md

### DIFF
--- a/app_nextcloud_fr.md
+++ b/app_nextcloud_fr.md
@@ -31,7 +31,7 @@ systemctl stop nginx
 Pour l'instant seul root peut y écrire dans `/media/stockage`; ce qui signifie que nginx et nextcloud ne pourront donc pas l'utiliser.
 
 ```bash
-chown -R nextcloud:www-data /media/stockage
+chown -R nextcloud:nextcloud /media/stockage
 chmod 775 -R /media/stockage
 ```
 


### PR DESCRIPTION
En suivant la doc sur l'installation de NextCloud et d'un stockage externe, j'ai rencontré un petit soucis. J'ai installé Yunohost sur Raspberry Pi 3B +, et lors de la copie des données de Nextcloud sur un disque externe, je n'avais pas les droits. Après avoir regardé le user:group sur l'installation initiale (dans /home/yunohost.app/nextcloud), j'ai noté que le groupe n'était pas www-data mais nextcloud.
Je ne sais pas si c'est spécifique à Raspbian, mais je me suis dit que ça pouvait servir, et qu'on pourrait le préciser.

(et merci pour la distrib, je viens juste de l'installer, c'est top !)