### PR TITLE
Updating XMPP (_en) docs to make explicit how to use XMPP account.

### DIFF
--- a/XMPP.md
+++ b/XMPP.md
@@ -33,7 +33,6 @@ You can connect to your YunoHost XMPP account in different ways.
 
 ### Mobile clients
 
-Or a mobile client such as:
 - [Xabber](http://xabber.com) (Android)
 - [Conversations](https://conversations.im/) (Android)
 - [Movim under Android](https://movim.eu)

--- a/XMPP.md
+++ b/XMPP.md
@@ -24,7 +24,6 @@ You can connect to your YunoHost XMPP account in different ways.
 
 ### Desktop clients
 
-You can also use a desktop client such as :
 - [Pidgin](http://pidgin.im/) (multiplatform),
 - [Gajim](http://gajim.org/) (Linux, Windows),
 - [Dino](https://dino.im) (Linux),

--- a/XMPP.md
+++ b/XMPP.md
@@ -1,6 +1,6 @@
 # Chat, VoIP and social network with <img src="/images/XMPP_logo.png" width=100>
 
-YunoHost comes installed with an instant messaging server Metronome which implements the [XMPP protocol](https://en.wikipedia.org/wiki/Extensible_Messaging_and_Presence_Protocol)(previously known as Jabber), by default.
+YunoHost comes installed by default with an instant messaging server Metronome which implements the [XMPP protocol](https://en.wikipedia.org/wiki/Extensible_Messaging_and_Presence_Protocol) (previously known as Jabber).
 
 This protocol is already used by millions of people around the world - it is an open protocol. All applications based on XMPP are compatible with each other: when using an XMPP client, you can interact with anybody who has an XMPP account.
 

--- a/XMPP.md
+++ b/XMPP.md
@@ -10,7 +10,7 @@ XMPP is an extensible protocol - this means users can configure "extensions" to 
 
 To use an XMPP account you need a username, which takes the format: `user@domain.tld`, and a password.
 
-With YunoHost, an XMPP account is created for a registered account automatically. The XMPP account can be used with the main email address and her YunoHost password.
+With YunoHost, an XMPP account is created for all YunoHost users automatically. The XMPP account credentials corresponds to the user's main email address and password.
 
 ## Connecting to your YunoHost XMPP account
 

--- a/XMPP.md
+++ b/XMPP.md
@@ -18,7 +18,6 @@ You can connect to your YunoHost XMPP account in different ways.
 
 ### Web clients
 
-There are several XMPP web clients:
 - [Movim](https://pod.movim.eu)
 - [Libervia/Salut à Toi](http://salut-a-toi.org/).
 

--- a/XMPP.md
+++ b/XMPP.md
@@ -1,53 +1,62 @@
 # Chat, VoIP and social network with <img src="/images/XMPP_logo.png" width=100>
 
-YunoHost comes installed with an instant messaging server Metronome which implements the [XMPP protocol](https://en.wikipedia.org/wiki/Extensible_Messaging_and_Presence_Protocol).
+YunoHost comes installed with an instant messaging server Metronome which implements the [XMPP protocol](https://en.wikipedia.org/wiki/Extensible_Messaging_and_Presence_Protocol)(previously known as Jabber), by default.
 
-XMPP is an open and extensible protocol which allows to create chatrooms, to share status and data, to give calls in VoIP and videoconferences.
+This protocol is already used by millions of people around the world - it is an open protocol. All applications based on XMPP are compatible with each other: when using an XMPP client, you can interact with anybody who has an XMPP account.
 
-All applications based on XMPP are compatible with each other : when using an XMPP client, you can interact with anybody who has an XMPP/Jabber account. This protocol is already used by millions of people around the world.
+XMPP is an extensible protocol - this means users can configure "extensions" to chatrooms, to share messages and files, and to make voice and video calls using XMPP.
 
-### XMPP/Jabber account
+## XMPP account
 
-An XMPP/Jabber account is based on an identifier with the structure `user@domain.tld`, and a password.
+To use an XMPP account you need a username, which takes the format: `user@domain.tld`, and a password.
 
-In YunoHost, this identifier simply corresponds to the main email address of a user, with his regular password.
+With YunoHost, an XMPP account is created for a registered account automatically. The XMPP account can be used with the main email address and her YunoHost password.
 
-### Connecting to XMPP 
+## Connecting to your YunoHost XMPP account
 
-There are several web client built with social network features :
+You can connect to your YunoHost XMPP account in different ways.
+
+### Web clients
+
+There are several XMPP web clients:
 - [Movim](https://pod.movim.eu)
 - [Libervia/Salut à Toi](http://salut-a-toi.org/).
 
+
+### Desktop clients
+
 You can also use a desktop client such as :
-- [Pidgin](http://pidgin.im/) (multiplatform), 
+- [Pidgin](http://pidgin.im/) (multiplatform),
 - [Gajim](http://gajim.org/) (Linux, Windows),
 - [Dino](https://dino.im) (Linux),
-- [Thunderbird](https://www.thundebird.net/) (multiplatform), 
-- [Jitsi](http://jitsi.org/) (multiplatform) 
+- [Thunderbird](https://www.thundebird.net/) (multiplatform),
+- [Jitsi](http://jitsi.org/) (multiplatform)
 - [Adium](https://adium.im/) (Mac OS).
 
-... or a mobile client
-* [Xabber](http://xabber.com) (Android)
-* [Conversations](https://conversations.im/) (Android)
-* [Movim under Android](https://movim.eu)
-* [Monal](https://itunes.apple.com/us/app/monal-free-xmpp-chat/id317711500?mt=8) (iOS)
+### Mobile clients
+
+Or a mobile client such as:
+- [Xabber](http://xabber.com) (Android)
+- [Conversations](https://conversations.im/) (Android)
+- [Movim under Android](https://movim.eu)
+- [Monal](https://itunes.apple.com/us/app/monal-free-xmpp-chat/id317711500?mt=8) (iOS)
 
 Here is an exhaustive list of XMPP clients : https://en.wikipedia.org/wiki/Comparison_of_XMPP_clients
 
-### Encrypt conversations with OMEMO
+## Encrypt conversations with OMEMO
 
-XMPP chats can be encrypted with the help of [OMEMO](https://xmpp.org/extensions/xep-0384.html), for instance using Gajim :
-* Install `gajim` and the plugin `gajim-omemo`
-* Enable the plugin in `Tools > Plugins`
-* Enable it
-* Enable the encryption in the chat with somebody who also has OMEMO
+XMPP chats can be made secure and private using [OMEMO] encryption (https://xmpp.org/extensions/xep-0384.html), for instance using Gajim:
+- Install `gajim` and the plugin `gajim-omemo`
+- Enable the plugin in `Tools > Plugins`
+- Enable it
+- Enable the encryption in the chat with somebody who also has OMEMO
 
-### Chatrooms
+## Chatrooms
 
 To create a chatroom (multi-user chat) on your YunoHost server, use the identifier `chatroomname@muc.yourdomain.tld`.
 
 For this to work you need to [add the corresponding `muc.` DNS record](dns_config_fr) in the DNS configuration.
 
-### VoIP and videoconferences
+## VoIP and videoconferences
 
 A practical tool to call an XMPP client, either with voice or voice+video, is to use the client [Jitsi](http://jitsi.org/).

--- a/XMPP_fr.md
+++ b/XMPP_fr.md
@@ -1,32 +1,37 @@
 #Chat, VoIP et réseau social avec <img src="/images/XMPP_logo.png" width=100>
 
-Yunohost est installé avec un serveur de messagerie instantanée Metronome qui implémente le [protocole XMPP](https://fr.wikipedia.org/wiki/Extensible_Messaging_and_Presence_Protocol).
+Yunohost est installé par défaut avec un serveur de messagerie instantanée Metronome qui implémente le [protocole XMPP](https://fr.wikipedia.org/wiki/Extensible_Messaging_and_Presence_Protocol) (anciennement connu sous le nom Jabber).
 
-XMPP est un protocole ouvert et extensible qui permet également de créer des salons de discussions, de partager des statuts et des données, de passer des appels en VoIP et de faire de la visioconférence.
+Ce protocole est déjà utilisé par des millions de personnes dans le monde - c'est un protocole ouvert. Toutes les applications basées sur XMPP sont compatibles entre elles : lorsque vous utilisez un client XMPP, vous pouvez interagir avec quiconque possède un compte XMPP.
 
-Toutes les applications basées sur XMPP sont compatibles entre-elles : lorsque vous utilisez un client XMPP vous pouvez discuter avec n’importe quel possesseur d’un compte XMPP/Jabber. Ce protocole est déjà utilisé par des millions de personnes dans le monde.
+XMPP est un protocole extensible - cela signifie que les utilisateurs peuvent configurer des "extensions" pour les salons de discussions, partager des messages et des fichiers, et passer des appels voix et vidéo en utilisant XMPP.
 
-### Compte XMPP/Jabber
+## Compte XMPP
 
-Un compte XMPP/Jabber est basé sur un identifiant sous la forme `utilisateur@domaine.tld`, ainsi qu’un mot de passe.
+Pour utiliser XMPP, il est nécessaire de disposer d'un compte dont l'identifiant prends la forme `utilisateur@domaine.tld`, ainsi qu’un mot de passe.
 
-Sous Yunohost, cet identifiant correspond simplement à l’adresse courriel principale d’un utilisateur. Le mot de passe est celui du compte de l’utilisateur.
+Sous Yunohost, un compte XMPP est créé automatiquement pour chaque utilisateur. Les identifiants XMPP sont simplement l’adresse courriel principale de l'utilisateur ainsi que son mot de passe.
 
-### Se connecter à XMPP
+## Se connecter à son compte XMPP YunoHost
 
-Il existe des clients web orientés réseau social, comme :
+Il existe différents types de clients pour se connecter à XMPP.
+
+### Clients web
+
 - [Movim](https://pod.movim.eu)
 - [Libervia/Salut à Toi](http://salut-a-toi.org/).
 
-Vous pouvez également utiliser un client desktop comme 
-- [Pidgin](http://pidgin.im/) (multiplateforme), 
+### Clients de bureau
+
+- [Pidgin](http://pidgin.im/) (multiplateforme),
 - [Gajim](http://gajim.org/index.fr.html) (Linux, Windows),
 - [Dino](https://dino.im) (Linux),
-- [Thunderbird](https://www.mozilla.org/fr/thunderbird/) (multiplateforme), 
-- [Jitsi](http://jitsi.org/) (multiplateforme) 
+- [Thunderbird](https://www.mozilla.org/fr/thunderbird/) (multiplateforme),
+- [Jitsi](http://jitsi.org/) (multiplateforme)
 - [Adium](https://adium.im/) (Mac OS).
 
-... ou un client smartphone
+### Clients sur mobile
+
 * [Xabber](http://xabber.com) (Android)
 * [Conversations](https://conversations.im/) (Android)
 * [Movim sous Android](https://movim.eu)
@@ -34,20 +39,20 @@ Vous pouvez également utiliser un client desktop comme
 
 Voici une liste plus exhaustive des clients XMPP : https://fr.wikipedia.org/wiki/Liste_de_clients_XMPP
 
-### Chiffrer ses conversations avec OMEMO
+## Chiffrer ses conversations avec OMEMO
 
-Il est possible de chiffrer ses conversations XMPP à l’aide de [OMEMO](https://xmpp.org/extensions/xep-0384.html), notamment en utilisant Gajim :
-* Installer `gajim` et le plugin `gajim-omemo`
-* Activez le plugins dans `Outils > Plugins`
-* L'activer
-* Activez le chiffrement dans une conversation avec un contact disposant de OMEMO.
+Il est possible de rendre les conversations plus sécurisées et privées en les chiffrants à l'aide de [OMEMO](https://xmpp.org/extensions/xep-0384.html), notamment en utilisant Gajim :
+- Installer `gajim` et le plugin `gajim-omemo`
+- Activez le plugins dans `Outils > Plugins`
+- L'activer
+- Activez le chiffrement dans une conversation avec un contact disposant de OMEMO.
 
-### Salon de discussion
+## Salon de discussion
 
 Pour créer un salon de discussion (Multi-user chat) sur votre serveur Yunohost utilisez l’identifiant nomsalon@muc.domaine.tld (où domaine.tld est le domaine principal de votre serveur).
 
 Si vous utilisez un nom de domaine personnel, il est nécessaire d’[ajouter une redirection de type CNAME pour le sous domaine `muc.`](dns_config_fr) au niveau de votre serveur DNS.
 
-### VoIP et visioconférence
+## VoIP et visioconférence
 
 Un moyen pratique d’appeler un contact XMPP, en VoIP ou en appel vidéo, est d’utiliser le client [Jitsi](http://jitsi.org/).


### PR DESCRIPTION
As discussed on #yunohost irc - it seems the information to make it clear that all Yunohost users have an XMPP account *by default* is a bit buried in the XMPP docs. 

To improve it for users, this is edit is the first step.