### PR TITLE
Update app catalog page

### DIFF
--- a/apps.md
+++ b/apps.md
@@ -234,6 +234,7 @@ $(document).ready(function () {
         filter();
     });
 
+    filter();
 
     //=================================================
     // Upload apps lists

--- a/apps.md
+++ b/apps.md
@@ -1,4 +1,4 @@
-# Apps
+# Application catalog
 
 <span class="javascriptDisclaimer">
 This page requires Javascript enabled to display properly :s.
@@ -6,34 +6,49 @@ This page requires Javascript enabled to display properly :s.
 <br/>
 </span>
 
+<!--
+Search bar
+-->
+
 <div class="input-group">
-    <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-search"></span></span>
-    <input type="text" id="filter-app-cards" class="form-control"  placeholder="Search for apps..." aria-describedby="basic-addon1"/>
+    <span id="basic-addon1" class="input-group-addon" ><span class="glyphicon glyphicon-search"></span></span>
+    <input id="filter-app-cards" type="text" class="form-control"  placeholder="Search for apps..." aria-describedby="basic-addon1"/>
     <div class="input-group-btn">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span id="app-cards-list-filter-text">Only official apps</span> <span class="caret"></span>
+            <span id="current-quality-filter" data-filter="decent">Only decent quality apps</span> <span class="caret"></span>
         </button>
+
         <ul class="dropdown-menu">
-            <li><a href="#" id="app-cards-list-validated">Only official apps</a></li>
-            <li><a href="#" id="app-cards-list-working">Only working apps</a></li>
-            <li><a href="#" id="app-cards-list-working-inprogress">In progress/not working apps</a></li>
-            <li><a href="#" id="app-cards-list-all-apps">All apps</a></li>
+            <li><a href="#" data-quality-filter="high">Only high quality apps</a></li>
+            <li><a href="#" data-quality-filter="decent">Only decent quality apps</a></li>
+            <li><a href="#" data-quality-filter="working">Only working apps</a></li>
+            <li><a href="#" data-quality-filter="none">All apps</a></li>
         </ul>
     </div>
 </div>
 <br />
-<div id="community-app-list-warrant" class="alert alert-danger">
-    <p>Only apps tagged <span class="label label-success label-as-badge">validated</span> are officially supported by the package team. </p>
 
-    <p>Apps tagged <span class="label label-success label-as-badge">working</span>, <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> are from community repository, you can test and use them **at your own risk**.</p>
+<!--
+Disclaimers
+-->
 
-    <p>Important: it's the application maintaineur that qualify his application as working, not the YunoHost core team. Install it at your own risks. We won't provide support for it.</p>
+<div class="alert alert-info">The application packaging team will welcome your feedback! If you install an app and find issues or possible improvements, do not hesitate to contribute by reporting your issues directly on the code repositories.</div>
+
+<div id="bad-quality-apps-disclaimer" class="alert alert-warning">
+    Applications with a level below or equal to 4 may be working, but they might be not well-integrated with YunoHost, or they do not respect the recommended packaging practices.
 </div>
-<div class="alert alert-info">The packagers will appreciate your remarks. If you install them and find issues, or ideas for improvement, do not hesitate to file issues directly on their repositories project page.</div>
 
-<div class="app-cards-list" id="app-cards-list"></div>
+<div id="broken-apps-disclaimer" class="alert alert-danger">
+    Applications with level 0, or flagged as <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> are still in development or are know to not be working. **Do not install them** in a production environment!
+</div>
 
-<div class="alert alert-warning">If you don't find the app you are searching for, you can search it in community app repository (working, inprogress and not working apps) or fill the <a href="/apps_wishlist_en">apps wishlist</a>.</div>
+<div id="app-cards-list" class="app-cards-list"></div>
+
+<div class="alert alert-warning">If you don't find the app you are looking for, you can try to look for a appname_ynh repository on Github or on the internet, or add it to the <a href="/apps_wishlist_en">apps wishlist</a>.</div>
+
+<!--
+Custom CSS for this page
+-->
 
 <style>
 /*=================================================
@@ -64,6 +79,7 @@ This page requires Javascript enabled to display properly :s.
     min-height: 1px;
     margin-right: 10px;
     margin-left: 10px;
+    border-radius: 3px;
 }
 /*===============================================*/
 
@@ -75,12 +91,17 @@ This page requires Javascript enabled to display properly :s.
     margin-bottom:5px;
     font-size:1.2em;
 }
-.app-card .category {
+.app-card .app-badges {
     height:35px;
 }
-.app-card .category .label, .app-card-date-maintainer {
-    font-size:0.7em;
+.app-card .app-badges .label, .app-card-date-maintainer {
+    font-size:0.6em;
 }
+
+.label-epic {
+    background-color: darkorchid;
+}
+
 .app-card-date-maintainer {
     text-align:right;
     max-height: 18px;
@@ -108,6 +129,8 @@ This page requires Javascript enabled to display properly :s.
 }
 .app-card > .btn-group > .btn{
     border-bottom:0;
+    font-size: 0.9em;
+    line-height: 1.58;
 }
 .app-card > .btn-group > .btn:first-child {
     border-left:0;
@@ -122,12 +145,16 @@ This page requires Javascript enabled to display properly :s.
 /*===============================================*/
 </style>
 
+<!--
+App card template
+-->
+
 <script type="text/template" id="app-template2">
-    <div class="app-card_{app_id} app-card panel panel-default">
+    <div class="app-card_{app_id} app-card panel panel-default" data-quality="{app_quality}">
 
         <div class="panel-body">
             <h3>{app_name}</h3>
-            <div class="category"></div>
+            <div class="app-badges"></div>
 
             <div class="app-card-desc">{app_description}</div>
         </div>
@@ -138,13 +165,18 @@ This page requires Javascript enabled to display properly :s.
         <div class="btn-group" role="group">
             <a href="{app_git}" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> Code</a>
             <a href="#/app_{app_id}_en" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> Doc</a>
-            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_bootstrap} col-sm-4 active"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Install</a>
+            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_css_style} col-sm-4 active"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Install</a>
         </div>
 
     </div>
 </script>
 
+<!--
+Javascript helpers
+-->
+
 <script>
+
 function timeConverter(UNIX_timestamp) {
     var a = new Date(UNIX_timestamp*1000);
     var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
@@ -159,19 +191,36 @@ function timeConverter(UNIX_timestamp) {
     return time;
 }
 
+
 $(document).ready(function () {
-    // Hide warrant about community list
-    $('#community-app-list-warrant').hide();
-    var filters = ["validated"];
+
+    // Hide warrant about states when we're using the default filter
+    $('#state-disclaimer').hide();
+    var quality_filters = "decent";
 
     function filter(){
-        var filters_text = filters.map(function(el) { return '.app-' + el;}).join(', ');
-        var valThis = $('#filter-app-cards').val().toLowerCase();
-        $('.app-card').each(function(){
-            var text = $(this).find('h3').text().toLowerCase();
-            (text.indexOf(valThis) >= 0 && $(this).find(filters_text).length > 0) ? $(this).show() : $(this).hide();
+
+        var current_quality_filter = $('#current-quality-filter').data("filter");
+        var user_input_in_search_field = $('#filter-app-cards').val().toLowerCase();
+
+        $('.app-card').each(function() {
+            // This is where we actually define how apps are filtered:
+            // we look for the name of the app (h3) and try to find the user input
+            // + we check this app match the current quality filter
+            var app_name = $(this).find('h3').text().toLowerCase();
+            if (app_name.indexOf(user_input_in_search_field) >= 0 && $(this).data("quality").indexOf(current_quality_filter) >= 0)
+            {
+                $(this).show();
+            }
+            else
+            {
+                $(this).hide();
+            }
         });
-        (filters.indexOf("working") == -1) ?$('#community-app-list-warrant').hide():$('#community-app-list-warrant').show();
+
+        // Display or hide the disclaimers depending on the current filter...
+        ((current_quality_filter == "working") || (current_quality_filter == "none")) ? $("#bad-quality-apps-disclaimer").show() : $("#bad-quality-apps-disclaimer").hide();
+        ((current_quality_filter == "none")) ? $("#broken-apps-disclaimer").show() : $("#broken-apps-disclaimer").hide();
     }
 
     //=================================================
@@ -179,81 +228,87 @@ $(document).ready(function () {
     //=================================================
     $('#filter-app-cards').keyup(filter);
 
-    $('#app-cards-list-validated').click(function(){
-        filters = ["validated"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-validated').text());
+    $('a[data-quality-filter]').on("click", function(){
+        $('#current-quality-filter').text($(this).text());
+        $('#current-quality-filter').data("filter", $(this).data("quality-filter"));
         filter();
     });
-
-    $('#app-cards-list-working').click(function(){
-        filters = ["validated", "working"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working').text());
-        filter();
-    });
-
-    $('#app-cards-list-working-inprogress').click(function(){
-        filters = ["notworking", "inprogress"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working-inprogress').text());
-        filter();
-    });
-
-    $('#app-cards-list-all-apps').click(function(){
-        filters = ["validated", "working", "inprogress", "notworking"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-all-apps').text());
-        filter();
-    });
-    //=================================================
 
 
     //=================================================
     // Upload apps lists
     //=================================================
-    var app_list={};
-    $.when(
-        $.getJSON('https://app.yunohost.org/community.json', {}, function(community) {
-            app_list.community = $.map(community, function(el) { return el; });
-        }),
-        $.getJSON('https://app.yunohost.org/official.json', {}, function(official) {
-            app_list.official = $.map(official, function(el) { return el; });
-        })
-    ).then(function() {
-        app_list = app_list.official.concat(app_list.community);
+    var catalog = undefined;
 
-        // Sort alpha
-        app_list.sort(function(a, b){
-            a_state = (a.state == "validated")?4:(a.state == "working")?3:(a.state == "inprogress")?2:1;
-            b_state = (b.state == "validated")?4:(b.state == "working")?3:(b.state == "inprogress")?2:1;
+    // Fetch application catalog
+
+    $.getJSON('https://app.yunohost.org/apps.json', {}, function(data) {
+
+        catalog = $.map(data, function(el) { return el; });
+
+        // Clarify high quality state, and level if undefined or inprogress or notworking...
+
+        $.each(catalog, function(k, infos) {
+            if ((infos.level === undefined) || (infos.state === "inprogress") || (infos.state === "notworking")) {
+                infos.level = null;
+            }
+            if ((infos.high_quality === true) && (infos.level === 8)) {
+                infos.state = "high quality";
+            }
+        });
+
+        // Sort apps according to their state and level...
+
+        catalog.sort(function(a, b){
+            a_state = (a.state === "high quality")?4:(a.level > 4)?3:(a.state > 0)?2:1;
+            b_state = (b.state === "high quality")?4:(b.level > 4)?3:(b.state > 0)?2:1;
             if (a_state < b_state || a_state == b_state && a.level < b.level || a_state == b_state && a.level == b.level && a.manifest.id > b.manifest.id) {return 1;}
             else if (a.manifest.id == b.manifest.id) {return 0;}
             return -1;
         });
-        $.each(app_list, function(k, infos) {
+
+        // Add the card for each app
+
+        $.each(catalog, function(k, infos) {
+
             app_id = infos.manifest.id;
-            app_install_bootstrap = "success";
-            if (infos.state === "validated") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "working") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "inprogress") {
-                app_state_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.state === "notworking") {
-                app_state_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            }
-            if (infos.level == null ) {
-                infos.level = '?';
-            }
-            if (infos.level == 0 ) {
-                app_level_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            } else if (infos.level <= 2) {
-                app_level_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.level >= 7) {
-                app_level_bootstrap = "success";
+
+            // Define what style to use for state, level and install button
+            // according to the app quality ....
+
+            if (infos.state === "high quality") {
+                app_quality = "high,decent,working,none";
+                app_state_css_style = "epic";
+                app_install_css_style = "success";
+                app_level_css_style = "epic";
+            } else if (infos.level > 4) {
+                app_quality = "decent,working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "success";
+                app_level_css_style = "success";
+            } else if (infos.level > 0) {
+                app_quality = "working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "warning";
+                app_level_css_style = "warning";
             } else {
-                app_level_bootstrap = "default";
+                app_quality = "none";
+                if (infos.state === "working") {
+                    app_state_css_style = "success";
+                }
+                else if (infos.state === "inprogress") {
+                    app_state_css_style = "warning";
+                }
+                else {
+                    app_state_css_style = "danger";
+                }
+                app_install_css_style = "danger";
+                app_level_css_style = "danger";
+            }
+
+            // If level is null, we wanna display '?'
+            if (infos.level == null) {
+                infos.level = '?';
             }
 
             // Fill the template
@@ -264,10 +319,12 @@ $(document).ready(function () {
              .replace(/{app_git}/g, infos.git.url)
              .replace('{app_branch}', infos.git.branch)
              .replace('{app_level}', infos.level)
+             .replace('{app_quality}', app_quality)
              .replace('{app_update}', timeConverter(infos.lastUpdate))
-             .replace('{app_state_bootstrap}', app_state_bootstrap)
-             .replace('{app_install_bootstrap}', app_install_bootstrap);
+             .replace('{app_state_css_style}', app_state_css_style)
+             .replace('{app_install_css_style}', app_install_css_style);
 
+            // Handle the maintainer info
             if (infos.maintained == false)
             {
                html = html
@@ -275,34 +332,34 @@ $(document).ready(function () {
                  .replace('{maintained_icon}', 'warning-sign')
                  .replace('{app_maintainer}', "Unmaintained")
                  .replace('{maintained_help}', "This package is currently unmaintained. Feel free to propose yourself as the new maintainer !");
-            } else {
-            if (infos.manifest.developer) {
+            }
+            else {
                 html = html
                  .replace('{maintained_state}', 'maintained')
                  .replace('{maintained_icon}', 'user')
-                 .replace('{app_maintainer}', infos.manifest.developer.name)
                  .replace('{maintained_help}', "Current maintainer of this package");
-            }
-            if (infos.manifest.maintainer) {
-                html = html
-                 .replace('{maintained_state}', 'maintained')
-                 .replace('{maintained_icon}', 'user')
-                 .replace('{app_maintainer}', infos.manifest.maintainer.name)
-                 .replace('{maintained_help}', "Current maintainer of this package");;
-            }
-            }
 
+                if ((infos.manifest.developer) && (infos.manifest.developer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.developer.name);
+                }
+                else if ((infos.manifest.maintainer) && (infos.manifest.maintainer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.maintainer.name);
+                }
+                else {
+                    html = html.replace('{app_maintainer}', "???");
+                }
+            }
 
             // Fill the template
             $('#app-cards-list').append(html);
             $('.app-card_'+ app_id).attr('id', 'app-card_'+ app_id);
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_level_bootstrap+' label-as-badge">'+infos.level+'</span>');
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_state_bootstrap+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
-            if (infos.manifest.license && infos.manifest.license != 'free') {
-                $('.app-card_'+ app_id + ' .category').append(' <span class="label label-default">'+infos.manifest.license+'</span>');
+            $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_state_css_style+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
+            if ((infos.state === "high quality") || (infos.state === "working")) {
+                $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_level_css_style+' label-as-badge">level '+infos.level+'</span>');
             }
 
         });
+
         filter();
     });
     //=================================================

--- a/apps_ar.md
+++ b/apps_ar.md
@@ -1,4 +1,4 @@
-# <div dir="rtl">التطبيقات</div>
+# Application catalog
 
 <span class="javascriptDisclaimer">
 This page requires Javascript enabled to display properly :s.
@@ -6,34 +6,49 @@ This page requires Javascript enabled to display properly :s.
 <br/>
 </span>
 
-<div dir="rtl" class="input-group">
-    <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-search"></span></span>
-    <input type="text" id="filter-app-cards" class="form-control"  placeholder="البحث عن تطبيقات ..." aria-describedby="basic-addon1"/>
-    <div dir="rtl" class="input-group-btn">
+<!--
+Search bar
+-->
+
+<div class="input-group">
+    <span id="basic-addon1" class="input-group-addon" ><span class="glyphicon glyphicon-search"></span></span>
+    <input id="filter-app-cards" type="text" class="form-control"  placeholder="Search for apps..." aria-describedby="basic-addon1"/>
+    <div class="input-group-btn">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span id="app-cards-list-filter-text">التطبيقات الرسمية فقط</span> <span class="caret"></span>
+            <span id="current-quality-filter" data-filter="decent">Only decent quality apps</span> <span class="caret"></span>
         </button>
+
         <ul class="dropdown-menu">
-            <li><a href="#" id="app-cards-list-validated">التطبيقات الرسمية فقط</a></li>
-            <li><a href="#" id="app-cards-list-working">التطبيقات "التي تعمل" فقط</a></li>
-            <li><a href="#" id="app-cards-list-working-inprogress">التطبيقات "الجاري العمل عليها"/"و التي لاتعمل"</a></li>
-            <li><a href="#" id="app-cards-list-all-apps">كافة التطبيقات</a></li>
+            <li><a href="#" data-quality-filter="high">Only high quality apps</a></li>
+            <li><a href="#" data-quality-filter="decent">Only decent quality apps</a></li>
+            <li><a href="#" data-quality-filter="working">Only working apps</a></li>
+            <li><a href="#" data-quality-filter="none">All apps</a></li>
         </ul>
     </div>
 </div>
 <br />
-<div dir="rtl" id="community-app-list-warrant" class="alert alert-danger">
-    <p>إلّا التطبيقات المحددة بعلامة <span class="label label-success label-as-badge">validated</span> تعتبر مدعومة رسميا من طرف فريق التحزيم. </p>
 
-    <p>Les apps marquées <span class="label label-success label-as-badge">working</span>, <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> sont des applications non officielles maintenues par la communauté, vous pouvez les tester et les utiliser **à vos risques et périls**.</p>
+<!--
+Disclaimers
+-->
 
-    <p>Important: c'est le mainteneur de l'application qui définit son application comme "working" et non pas l'équipe d'empaquetage de Yunohost. Installez ces apps à vos risques et périls. Nous ne fournissons pas de support pour elles.</p>
+<div class="alert alert-info">The application packaging team will welcome your feedback! If you install an app and find issues or possible improvements, do not hesitate to contribute by reporting your issues directly on the code repositories.</div>
+
+<div id="bad-quality-apps-disclaimer" class="alert alert-warning">
+    Applications with a level below or equal to 4 may be working, but they might be not well-integrated with YunoHost, or they do not respect the recommended packaging practices.
 </div>
-<div dir="rtl"class="alert alert-info">إنّ فريق التحزيم سوف يأخذ بعين الإعتبار ملاحظاتكم. مثال، إن قمتم بتنصيب تطبيقاتهم و عارضتكم مشاكل أو إن كلمة عندكم أفكارا لتحسين التطبيقات، فلا تبخلوا التحو تذكرة مباشرة على صفحات مستودعات المشاريع نفسها</div>
 
-<div class="app-cards-list" id="app-cards-list"></div>
+<div id="broken-apps-disclaimer" class="alert alert-danger">
+    Applications with level 0, or flagged as <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> are still in development or are know to not be working. **Do not install them** in a production environment!
+</div>
 
-<div dir="rtl"  class="alert alert-warning">إن لم تتمكنوا من العثور على التطبيق الذي تبحثون عنه هنا، يمكنكم البحث كذلك في مستودع تطبيقات المجتمع (التي تعمل، الجاري العمل عليها و التي لا تعمل) أو قوموا بإضافتها إلى <a href="/apps_wishlist_fr">قائمة التطبيقات المرغوب فيها</a>.</div>
+<div id="app-cards-list" class="app-cards-list"></div>
+
+<div class="alert alert-warning">If you don't find the app you are looking for, you can try to look for a appname_ynh repository on Github or on the internet, or add it to the <a href="/apps_wishlist_en">apps wishlist</a>.</div>
+
+<!--
+Custom CSS for this page
+-->
 
 <style>
 /*=================================================
@@ -64,6 +79,7 @@ This page requires Javascript enabled to display properly :s.
     min-height: 1px;
     margin-right: 10px;
     margin-left: 10px;
+    border-radius: 3px;
 }
 /*===============================================*/
 
@@ -75,18 +91,27 @@ This page requires Javascript enabled to display properly :s.
     margin-bottom:5px;
     font-size:1.2em;
 }
-.app-card .category {
+.app-card .app-badges {
     height:35px;
 }
-.app-card .category .label, .app-card-date-maintainer {
-    font-size:0.7em;
+.app-card .app-badges .label, .app-card-date-maintainer {
+    font-size:0.6em;
 }
+
+.label-epic {
+    background-color: darkorchid;
+}
+
 .app-card-date-maintainer {
     text-align:right;
     max-height: 18px;
     margin-bottom: 3px;
     margin-right: 7px;
     margin-top: -5px;
+}
+
+.app-card .unmaintained {
+   color: #e0aa33;
 }
 
 .app-card-desc {
@@ -104,8 +129,10 @@ This page requires Javascript enabled to display properly :s.
 }
 .app-card > .btn-group > .btn{
     border-bottom:0;
+    font-size: 0.9em;
+    line-height: 1.58;
 }
-.app-card > .btn-group > .btn:first-child {   
+.app-card > .btn-group > .btn:first-child {
     border-left:0;
     border-top-left-radius:0;
 }
@@ -118,33 +145,41 @@ This page requires Javascript enabled to display properly :s.
 /*===============================================*/
 </style>
 
+<!--
+App card template
+-->
+
 <script type="text/template" id="app-template2">
-    <div class="app-card_{app_id} app-card panel panel-default">
+    <div class="app-card_{app_id} app-card panel panel-default" data-quality="{app_quality}">
 
         <div class="panel-body">
             <h3>{app_name}</h3>
-            <div class="category"></div>
+            <div class="app-badges"></div>
 
             <div class="app-card-desc">{app_description}</div>
         </div>
-
             <div class="app-card-date-maintainer">
-                <span class="glyphicon glyphicon-refresh"></span> {app_update} - 
-                <span class="glyphicon glyphicon-user"></span> {app_maintainer}
+                <span class="glyphicon glyphicon-refresh"></span> {app_update} -
+                <span title="{maintained_help}" class="{maintained_state}"><span class="glyphicon glyphicon-{maintained_icon}"></span> {app_maintainer}</span>
             </div>
         <div class="btn-group" role="group">
-            <a href="{app_git}" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> الشفرة</a>
-            <a href="#/app_{app_id}_fr" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> الدليل</a>
-            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_bootstrap} col-sm-4 active">تنصيب</a>
+            <a href="{app_git}" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> Code</a>
+            <a href="#/app_{app_id}_en" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> Doc</a>
+            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_css_style} col-sm-4 active"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Install</a>
         </div>
 
-    </div> 
+    </div>
 </script>
 
+<!--
+Javascript helpers
+-->
+
 <script>
+
 function timeConverter(UNIX_timestamp) {
     var a = new Date(UNIX_timestamp*1000);
-    var months = ['جانفي','فيفري','مارس','أفريل','ماي','جوان','جويلية','أوت','سبتمبر','أكتوبر','نوفمبر','ديسمبر'];
+    var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
     var year = a.getFullYear();
     var month = months[a.getMonth()];
     var date = a.getDate();
@@ -156,19 +191,36 @@ function timeConverter(UNIX_timestamp) {
     return time;
 }
 
+
 $(document).ready(function () {
-    // Hide warrant about community list
-    $('#community-app-list-warrant').hide();
-    var filters = ["validated"];
+
+    // Hide warrant about states when we're using the default filter
+    $('#state-disclaimer').hide();
+    var quality_filters = "decent";
 
     function filter(){
-        var filters_text = filters.map(function(el) { return '.app-' + el;}).join(', ');
-        var valThis = $('#filter-app-cards').val().toLowerCase();
-        $('.app-card').each(function(){
-            var text = $(this).find('h3').text().toLowerCase();
-            (text.indexOf(valThis) >= 0 && $(this).find(filters_text).length > 0) ? $(this).show() : $(this).hide();
+
+        var current_quality_filter = $('#current-quality-filter').data("filter");
+        var user_input_in_search_field = $('#filter-app-cards').val().toLowerCase();
+
+        $('.app-card').each(function() {
+            // This is where we actually define how apps are filtered:
+            // we look for the name of the app (h3) and try to find the user input
+            // + we check this app match the current quality filter
+            var app_name = $(this).find('h3').text().toLowerCase();
+            if (app_name.indexOf(user_input_in_search_field) >= 0 && $(this).data("quality").indexOf(current_quality_filter) >= 0)
+            {
+                $(this).show();
+            }
+            else
+            {
+                $(this).hide();
+            }
         });
-        (filters.indexOf("working") == -1) ?$('#community-app-list-warrant').hide():$('#community-app-list-warrant').show();
+
+        // Display or hide the disclaimers depending on the current filter...
+        ((current_quality_filter == "working") || (current_quality_filter == "none")) ? $("#bad-quality-apps-disclaimer").show() : $("#bad-quality-apps-disclaimer").hide();
+        ((current_quality_filter == "none")) ? $("#broken-apps-disclaimer").show() : $("#broken-apps-disclaimer").hide();
     }
 
     //=================================================
@@ -176,120 +228,141 @@ $(document).ready(function () {
     //=================================================
     $('#filter-app-cards').keyup(filter);
 
-    $('#app-cards-list-validated').click(function(){
-        filters = ["validated"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-validated').text());
+    $('a[data-quality-filter]').on("click", function(){
+        $('#current-quality-filter').text($(this).text());
+        $('#current-quality-filter').data("filter", $(this).data("quality-filter"));
         filter();
     });
 
-    $('#app-cards-list-working').click(function(){
-        filters = ["validated", "working"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working').text());
-        filter();
-    });
-
-    $('#app-cards-list-working-inprogress').click(function(){
-        filters = ["notworking", "inprogress"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working-inprogress').text());
-        filter();
-    });
-
-    $('#app-cards-list-all-apps').click(function(){
-        filters = ["validated", "working", "inprogress", "notworking"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-all-apps').text());
-        filter();
-    }); 
-    //=================================================  
-
+    filter();
 
     //=================================================
     // Upload apps lists
     //=================================================
-    var app_list={};
-    $.when(
-        $.getJSON('https://app.yunohost.org/community.json', {}, function(community) {
-            app_list.community = $.map(community, function(el) { return el; });
-        }),
-        $.getJSON('https://app.yunohost.org/official.json', {}, function(official) {
-            app_list.official = $.map(official, function(el) { return el; });
-        })
-    ).then(function() {
-        app_list = app_list.official.concat(app_list.community);
-    
-        // Sort alpha
-        app_list.sort(function(a, b){
-            a_state = (a.state == "validated")?4:(a.state == "working")?3:(a.state == "inprogress")?2:1;
-            b_state = (b.state == "validated")?4:(b.state == "working")?3:(b.state == "inprogress")?2:1;
+    var catalog = undefined;
+
+    // Fetch application catalog
+
+    $.getJSON('https://app.yunohost.org/apps.json', {}, function(data) {
+
+        catalog = $.map(data, function(el) { return el; });
+
+        // Clarify high quality state, and level if undefined or inprogress or notworking...
+
+        $.each(catalog, function(k, infos) {
+            if ((infos.level === undefined) || (infos.state === "inprogress") || (infos.state === "notworking")) {
+                infos.level = null;
+            }
+            if ((infos.high_quality === true) && (infos.level === 8)) {
+                infos.state = "high quality";
+            }
+        });
+
+        // Sort apps according to their state and level...
+
+        catalog.sort(function(a, b){
+            a_state = (a.state === "high quality")?4:(a.level > 4)?3:(a.state > 0)?2:1;
+            b_state = (b.state === "high quality")?4:(b.level > 4)?3:(b.state > 0)?2:1;
             if (a_state < b_state || a_state == b_state && a.level < b.level || a_state == b_state && a.level == b.level && a.manifest.id > b.manifest.id) {return 1;}
             else if (a.manifest.id == b.manifest.id) {return 0;}
             return -1;
         });
-        $.each(app_list, function(k, infos) {
+
+        // Add the card for each app
+
+        $.each(catalog, function(k, infos) {
+
             app_id = infos.manifest.id;
-            app_install_bootstrap = "success";
-            if (infos.state === "validated") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "working") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "inprogress") {
-                app_state_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.state === "notworking") {
-                app_state_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            }
-            if (infos.level == null ) {
-                infos.level = '?';
-            }
-            if (infos.level == 0 ) {
-                app_level_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            } else if (infos.level <= 2) {
-                app_level_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.level >= 7) {
-                app_level_bootstrap = "success";
+
+            // Define what style to use for state, level and install button
+            // according to the app quality ....
+
+            if (infos.state === "high quality") {
+                app_quality = "high,decent,working,none";
+                app_state_css_style = "epic";
+                app_install_css_style = "success";
+                app_level_css_style = "epic";
+            } else if (infos.level > 4) {
+                app_quality = "decent,working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "success";
+                app_level_css_style = "success";
+            } else if (infos.level > 0) {
+                app_quality = "working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "warning";
+                app_level_css_style = "warning";
             } else {
-                app_level_bootstrap = "default";
+                app_quality = "none";
+                if (infos.state === "working") {
+                    app_state_css_style = "success";
+                }
+                else if (infos.state === "inprogress") {
+                    app_state_css_style = "warning";
+                }
+                else {
+                    app_state_css_style = "danger";
+                }
+                app_install_css_style = "danger";
+                app_level_css_style = "danger";
+            }
+
+            // If level is null, we wanna display '?'
+            if (infos.level == null) {
+                infos.level = '?';
             }
 
             // Fill the template
             html = $('#app-template2').html()
              .replace(/{app_id}/g, app_id)
              .replace(/{app_name}/g, infos.manifest.name)
-             .replace('{app_description}', infos.manifest.description.fr)
+             .replace('{app_description}', infos.manifest.description.en)
              .replace(/{app_git}/g, infos.git.url)
              .replace('{app_branch}', infos.git.branch)
              .replace('{app_level}', infos.level)
+             .replace('{app_quality}', app_quality)
              .replace('{app_update}', timeConverter(infos.lastUpdate))
-             .replace('{app_state_bootstrap}', app_state_bootstrap)
-             .replace('{app_install_bootstrap}', app_install_bootstrap);
+             .replace('{app_state_css_style}', app_state_css_style)
+             .replace('{app_install_css_style}', app_install_css_style);
 
-            if (infos.manifest.developer) {
-                html = html
-                 .replace('{app_maintainer}', infos.manifest.developer.name)
-                 .replace('{app_mail}', infos.manifest.developer.email);
+            // Handle the maintainer info
+            if (infos.maintained == false)
+            {
+               html = html
+                 .replace('{maintained_state}', 'unmaintained')
+                 .replace('{maintained_icon}', 'warning-sign')
+                 .replace('{app_maintainer}', "Unmaintained")
+                 .replace('{maintained_help}', "This package is currently unmaintained. Feel free to propose yourself as the new maintainer !");
             }
-
-            if (infos.manifest.maintainer) {
+            else {
                 html = html
-                 .replace('{app_maintainer}', infos.manifest.maintainer.name)
-                 .replace('{app_mail}', infos.manifest.maintainer.email);
+                 .replace('{maintained_state}', 'maintained')
+                 .replace('{maintained_icon}', 'user')
+                 .replace('{maintained_help}', "Current maintainer of this package");
+
+                if ((infos.manifest.developer) && (infos.manifest.developer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.developer.name);
+                }
+                else if ((infos.manifest.maintainer) && (infos.manifest.maintainer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.maintainer.name);
+                }
+                else {
+                    html = html.replace('{app_maintainer}', "???");
+                }
             }
 
             // Fill the template
             $('#app-cards-list').append(html);
             $('.app-card_'+ app_id).attr('id', 'app-card_'+ app_id);
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_level_bootstrap+' label-as-badge">'+infos.level+'</span>');
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_state_bootstrap+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
-            if (infos.manifest.license && infos.manifest.license != 'free') {
-                $('.app-card_'+ app_id + ' .category').append(' <span class="label label-default">'+infos.manifest.license+'</span>');
+            $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_state_css_style+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
+            if ((infos.state === "high quality") || (infos.state === "working")) {
+                $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_level_css_style+' label-as-badge">level '+infos.level+'</span>');
             }
 
         });
+
         filter();
     });
-    //=================================================  
+    //=================================================
 });
 </script>
-

--- a/apps_es.md
+++ b/apps_es.md
@@ -1,39 +1,54 @@
-# Apps
+# Application catalog
 
 <span class="javascriptDisclaimer">
-Esta página requiere que Javascript esté activado para aparecer correctamente :s.
+This page requires Javascript enabled to display properly :s.
 <br/>
 <br/>
 </span>
 
+<!--
+Search bar
+-->
+
 <div class="input-group">
-    <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-search"></span></span>
-    <input type="text" id="filter-app-cards" class="form-control"  placeholder="Rechercher des apps..." aria-describedby="basic-addon1"/>
+    <span id="basic-addon1" class="input-group-addon" ><span class="glyphicon glyphicon-search"></span></span>
+    <input id="filter-app-cards" type="text" class="form-control"  placeholder="Search for apps..." aria-describedby="basic-addon1"/>
     <div class="input-group-btn">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span id="app-cards-list-filter-text">Apps oficiales únicamente</span> <span class="caret"></span>
+            <span id="current-quality-filter" data-filter="decent">Only decent quality apps</span> <span class="caret"></span>
         </button>
+
         <ul class="dropdown-menu">
-            <li><a href="#" id="app-cards-list-validated">Apps oficiales únicamente</a></li>
-            <li><a href="#" id="app-cards-list-working">Apps "working" únicamente</a></li>
-            <li><a href="#" id="app-cards-list-working-inprogress">Apps "in progress"/"not working"</a></li>
-            <li><a href="#" id="app-cards-list-all-apps">Todas las apps</a></li>
+            <li><a href="#" data-quality-filter="high">Only high quality apps</a></li>
+            <li><a href="#" data-quality-filter="decent">Only decent quality apps</a></li>
+            <li><a href="#" data-quality-filter="working">Only working apps</a></li>
+            <li><a href="#" data-quality-filter="none">All apps</a></li>
         </ul>
     </div>
 </div>
 <br />
-<div id="community-app-list-warrant" class="alert alert-danger">
-    <p>Sólo las apps señaladas <span class="label label-success label-as-badge">validated</span> están oficialmente soportadas por el equipo de desarrollo de aplicaciones. </p>
 
-    <p>Las apps señaladas <span class="label label-success label-as-badge">working</span>, <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> son aplicaciones que son oficiales, mantenidas por la comunidad, puedes testarlas y utilizarlas **por tu cuenta y riesgo**.</p>
+<!--
+Disclaimers
+-->
 
-    <p>Importante: son los que mantienen la aplicación quienes definen su propia aplicación cómo "working", no es el equipo de desarrollo de aplicaciones de Yunohost. Instala estas aplicaciones por tu cuenta y riesgo. No proponemos servicios de soporte para ellas.</p>
+<div class="alert alert-info">The application packaging team will welcome your feedback! If you install an app and find issues or possible improvements, do not hesitate to contribute by reporting your issues directly on the code repositories.</div>
+
+<div id="bad-quality-apps-disclaimer" class="alert alert-warning">
+    Applications with a level below or equal to 4 may be working, but they might be not well-integrated with YunoHost, or they do not respect the recommended packaging practices.
 </div>
-<div class="alert alert-info">Los desarrolladores de aplicaciones te agradecerán tu comentarios. Si instalas sus apps y encuentras fallos, o si tienes ideas para mejorarlas, no dudes en crear tickets direactement en las páginas de depósitos de los proyectos.</div>
 
-<div class="app-cards-list" id="app-cards-list"></div>
+<div id="broken-apps-disclaimer" class="alert alert-danger">
+    Applications with level 0, or flagged as <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> are still in development or are know to not be working. **Do not install them** in a production environment!
+</div>
 
-<div class="alert alert-warning">Si no encuentras la aplicación que buscas, puedes buscarla en las aplicaciones comunitarias (working, inprogress y networking) o llenar la <a href="/apps_wishlist_en">lista de apps deseadas</a>.</div>
+<div id="app-cards-list" class="app-cards-list"></div>
+
+<div class="alert alert-warning">If you don't find the app you are looking for, you can try to look for a appname_ynh repository on Github or on the internet, or add it to the <a href="/apps_wishlist_en">apps wishlist</a>.</div>
+
+<!--
+Custom CSS for this page
+-->
 
 <style>
 /*=================================================
@@ -64,6 +79,7 @@ Esta página requiere que Javascript esté activado para aparecer correctamente 
     min-height: 1px;
     margin-right: 10px;
     margin-left: 10px;
+    border-radius: 3px;
 }
 /*===============================================*/
 
@@ -75,18 +91,27 @@ Esta página requiere que Javascript esté activado para aparecer correctamente 
     margin-bottom:5px;
     font-size:1.2em;
 }
-.app-card .category {
+.app-card .app-badges {
     height:35px;
 }
-.app-card .category .label, .app-card-date-maintainer {
-    font-size:0.7em;
+.app-card .app-badges .label, .app-card-date-maintainer {
+    font-size:0.6em;
 }
+
+.label-epic {
+    background-color: darkorchid;
+}
+
 .app-card-date-maintainer {
     text-align:right;
     max-height: 18px;
     margin-bottom: 3px;
     margin-right: 7px;
     margin-top: -5px;
+}
+
+.app-card .unmaintained {
+   color: #e0aa33;
 }
 
 .app-card-desc {
@@ -104,8 +129,10 @@ Esta página requiere que Javascript esté activado para aparecer correctamente 
 }
 .app-card > .btn-group > .btn{
     border-bottom:0;
+    font-size: 0.9em;
+    line-height: 1.58;
 }
-.app-card > .btn-group > .btn:first-child {   
+.app-card > .btn-group > .btn:first-child {
     border-left:0;
     border-top-left-radius:0;
 }
@@ -118,30 +145,38 @@ Esta página requiere que Javascript esté activado para aparecer correctamente 
 /*===============================================*/
 </style>
 
+<!--
+App card template
+-->
+
 <script type="text/template" id="app-template2">
-    <div class="app-card_{app_id} app-card panel panel-default">
+    <div class="app-card_{app_id} app-card panel panel-default" data-quality="{app_quality}">
 
         <div class="panel-body">
             <h3>{app_name}</h3>
-            <div class="category"></div>
+            <div class="app-badges"></div>
 
             <div class="app-card-desc">{app_description}</div>
         </div>
-
             <div class="app-card-date-maintainer">
-                <span class="glyphicon glyphicon-refresh"></span> {app_update} - 
-                <span class="glyphicon glyphicon-user"></span> {app_maintainer}
+                <span class="glyphicon glyphicon-refresh"></span> {app_update} -
+                <span title="{maintained_help}" class="{maintained_state}"><span class="glyphicon glyphicon-{maintained_icon}"></span> {app_maintainer}</span>
             </div>
         <div class="btn-group" role="group">
             <a href="{app_git}" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> Code</a>
-            <a href="#/app_{app_id}_fr" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> Doc</a>
-            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_bootstrap} col-sm-4 active">Installer</a>
+            <a href="#/app_{app_id}_en" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> Doc</a>
+            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_css_style} col-sm-4 active"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Install</a>
         </div>
 
-    </div> 
+    </div>
 </script>
 
+<!--
+Javascript helpers
+-->
+
 <script>
+
 function timeConverter(UNIX_timestamp) {
     var a = new Date(UNIX_timestamp*1000);
     var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
@@ -156,19 +191,36 @@ function timeConverter(UNIX_timestamp) {
     return time;
 }
 
+
 $(document).ready(function () {
-    // Hide warrant about community list
-    $('#community-app-list-warrant').hide();
-    var filters = ["validated"];
+
+    // Hide warrant about states when we're using the default filter
+    $('#state-disclaimer').hide();
+    var quality_filters = "decent";
 
     function filter(){
-        var filters_text = filters.map(function(el) { return '.app-' + el;}).join(', ');
-        var valThis = $('#filter-app-cards').val().toLowerCase();
-        $('.app-card').each(function(){
-            var text = $(this).find('h3').text().toLowerCase();
-            (text.indexOf(valThis) >= 0 && $(this).find(filters_text).length > 0) ? $(this).show() : $(this).hide();
+
+        var current_quality_filter = $('#current-quality-filter').data("filter");
+        var user_input_in_search_field = $('#filter-app-cards').val().toLowerCase();
+
+        $('.app-card').each(function() {
+            // This is where we actually define how apps are filtered:
+            // we look for the name of the app (h3) and try to find the user input
+            // + we check this app match the current quality filter
+            var app_name = $(this).find('h3').text().toLowerCase();
+            if (app_name.indexOf(user_input_in_search_field) >= 0 && $(this).data("quality").indexOf(current_quality_filter) >= 0)
+            {
+                $(this).show();
+            }
+            else
+            {
+                $(this).hide();
+            }
         });
-        (filters.indexOf("working") == -1) ?$('#community-app-list-warrant').hide():$('#community-app-list-warrant').show();
+
+        // Display or hide the disclaimers depending on the current filter...
+        ((current_quality_filter == "working") || (current_quality_filter == "none")) ? $("#bad-quality-apps-disclaimer").show() : $("#bad-quality-apps-disclaimer").hide();
+        ((current_quality_filter == "none")) ? $("#broken-apps-disclaimer").show() : $("#broken-apps-disclaimer").hide();
     }
 
     //=================================================
@@ -176,120 +228,141 @@ $(document).ready(function () {
     //=================================================
     $('#filter-app-cards').keyup(filter);
 
-    $('#app-cards-list-validated').click(function(){
-        filters = ["validated"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-validated').text());
+    $('a[data-quality-filter]').on("click", function(){
+        $('#current-quality-filter').text($(this).text());
+        $('#current-quality-filter').data("filter", $(this).data("quality-filter"));
         filter();
     });
 
-    $('#app-cards-list-working').click(function(){
-        filters = ["validated", "working"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working').text());
-        filter();
-    });
-
-    $('#app-cards-list-working-inprogress').click(function(){
-        filters = ["notworking", "inprogress"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working-inprogress').text());
-        filter();
-    });
-
-    $('#app-cards-list-all-apps').click(function(){
-        filters = ["validated", "working", "inprogress", "notworking"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-all-apps').text());
-        filter();
-    }); 
-    //=================================================  
-
+    filter();
 
     //=================================================
     // Upload apps lists
     //=================================================
-    var app_list={};
-    $.when(
-        $.getJSON('https://app.yunohost.org/community.json', {}, function(community) {
-            app_list.community = $.map(community, function(el) { return el; });
-        }),
-        $.getJSON('https://app.yunohost.org/official.json', {}, function(official) {
-            app_list.official = $.map(official, function(el) { return el; });
-        })
-    ).then(function() {
-        app_list = app_list.official.concat(app_list.community);
-    
-        // Sort alpha
-        app_list.sort(function(a, b){
-            a_state = (a.state == "validated")?4:(a.state == "working")?3:(a.state == "inprogress")?2:1;
-            b_state = (b.state == "validated")?4:(b.state == "working")?3:(b.state == "inprogress")?2:1;
+    var catalog = undefined;
+
+    // Fetch application catalog
+
+    $.getJSON('https://app.yunohost.org/apps.json', {}, function(data) {
+
+        catalog = $.map(data, function(el) { return el; });
+
+        // Clarify high quality state, and level if undefined or inprogress or notworking...
+
+        $.each(catalog, function(k, infos) {
+            if ((infos.level === undefined) || (infos.state === "inprogress") || (infos.state === "notworking")) {
+                infos.level = null;
+            }
+            if ((infos.high_quality === true) && (infos.level === 8)) {
+                infos.state = "high quality";
+            }
+        });
+
+        // Sort apps according to their state and level...
+
+        catalog.sort(function(a, b){
+            a_state = (a.state === "high quality")?4:(a.level > 4)?3:(a.state > 0)?2:1;
+            b_state = (b.state === "high quality")?4:(b.level > 4)?3:(b.state > 0)?2:1;
             if (a_state < b_state || a_state == b_state && a.level < b.level || a_state == b_state && a.level == b.level && a.manifest.id > b.manifest.id) {return 1;}
             else if (a.manifest.id == b.manifest.id) {return 0;}
             return -1;
         });
-        $.each(app_list, function(k, infos) {
+
+        // Add the card for each app
+
+        $.each(catalog, function(k, infos) {
+
             app_id = infos.manifest.id;
-            app_install_bootstrap = "success";
-            if (infos.state === "validated") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "working") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "inprogress") {
-                app_state_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.state === "notworking") {
-                app_state_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            }
-            if (infos.level == null ) {
-                infos.level = '?';
-            }
-            if (infos.level == 0 ) {
-                app_level_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            } else if (infos.level <= 2) {
-                app_level_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.level >= 7) {
-                app_level_bootstrap = "success";
+
+            // Define what style to use for state, level and install button
+            // according to the app quality ....
+
+            if (infos.state === "high quality") {
+                app_quality = "high,decent,working,none";
+                app_state_css_style = "epic";
+                app_install_css_style = "success";
+                app_level_css_style = "epic";
+            } else if (infos.level > 4) {
+                app_quality = "decent,working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "success";
+                app_level_css_style = "success";
+            } else if (infos.level > 0) {
+                app_quality = "working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "warning";
+                app_level_css_style = "warning";
             } else {
-                app_level_bootstrap = "default";
+                app_quality = "none";
+                if (infos.state === "working") {
+                    app_state_css_style = "success";
+                }
+                else if (infos.state === "inprogress") {
+                    app_state_css_style = "warning";
+                }
+                else {
+                    app_state_css_style = "danger";
+                }
+                app_install_css_style = "danger";
+                app_level_css_style = "danger";
+            }
+
+            // If level is null, we wanna display '?'
+            if (infos.level == null) {
+                infos.level = '?';
             }
 
             // Fill the template
             html = $('#app-template2').html()
              .replace(/{app_id}/g, app_id)
              .replace(/{app_name}/g, infos.manifest.name)
-             .replace('{app_description}', infos.manifest.description.fr)
+             .replace('{app_description}', infos.manifest.description.en)
              .replace(/{app_git}/g, infos.git.url)
              .replace('{app_branch}', infos.git.branch)
              .replace('{app_level}', infos.level)
+             .replace('{app_quality}', app_quality)
              .replace('{app_update}', timeConverter(infos.lastUpdate))
-             .replace('{app_state_bootstrap}', app_state_bootstrap)
-             .replace('{app_install_bootstrap}', app_install_bootstrap);
+             .replace('{app_state_css_style}', app_state_css_style)
+             .replace('{app_install_css_style}', app_install_css_style);
 
-            if (infos.manifest.developer) {
-                html = html
-                 .replace('{app_maintainer}', infos.manifest.developer.name)
-                 .replace('{app_mail}', infos.manifest.developer.email);
+            // Handle the maintainer info
+            if (infos.maintained == false)
+            {
+               html = html
+                 .replace('{maintained_state}', 'unmaintained')
+                 .replace('{maintained_icon}', 'warning-sign')
+                 .replace('{app_maintainer}', "Unmaintained")
+                 .replace('{maintained_help}', "This package is currently unmaintained. Feel free to propose yourself as the new maintainer !");
             }
-
-            if (infos.manifest.maintainer) {
+            else {
                 html = html
-                 .replace('{app_maintainer}', infos.manifest.maintainer.name)
-                 .replace('{app_mail}', infos.manifest.maintainer.email);
+                 .replace('{maintained_state}', 'maintained')
+                 .replace('{maintained_icon}', 'user')
+                 .replace('{maintained_help}', "Current maintainer of this package");
+
+                if ((infos.manifest.developer) && (infos.manifest.developer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.developer.name);
+                }
+                else if ((infos.manifest.maintainer) && (infos.manifest.maintainer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.maintainer.name);
+                }
+                else {
+                    html = html.replace('{app_maintainer}', "???");
+                }
             }
 
             // Fill the template
             $('#app-cards-list').append(html);
             $('.app-card_'+ app_id).attr('id', 'app-card_'+ app_id);
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_level_bootstrap+' label-as-badge">'+infos.level+'</span>');
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_state_bootstrap+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
-            if (infos.manifest.license && infos.manifest.license != 'free') {
-                $('.app-card_'+ app_id + ' .category').append(' <span class="label label-default">'+infos.manifest.license+'</span>');
+            $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_state_css_style+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
+            if ((infos.state === "high quality") || (infos.state === "working")) {
+                $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_level_css_style+' label-as-badge">level '+infos.level+'</span>');
             }
 
         });
+
         filter();
     });
-    //=================================================  
+    //=================================================
 });
 </script>
-

--- a/apps_fr.md
+++ b/apps_fr.md
@@ -1,4 +1,4 @@
-# Apps
+# Application catalog
 
 <span class="javascriptDisclaimer">
 Cette page requiert que Javascript soit activé pour s'afficher correctement :s.
@@ -6,34 +6,48 @@ Cette page requiert que Javascript soit activé pour s'afficher correctement :s.
 <br/>
 </span>
 
+<!--
+Search bar
+-->
 <div class="input-group">
-    <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-search"></span></span>
-    <input type="text" id="filter-app-cards" class="form-control"  placeholder="Rechercher des apps..." aria-describedby="basic-addon1"/>
+    <span id="basic-addon1" class="input-group-addon" ><span class="glyphicon glyphicon-search"></span></span>
+    <input id="filter-app-cards" type="text" class="form-control"  placeholder="Rechercher des apps..." aria-describedby="basic-addon1"/>
     <div class="input-group-btn">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span id="app-cards-list-filter-text">Apps officielles seulement</span> <span class="caret"></span>
+            <span id="current-quality-filter" data-filter="decent">Seulement les apps de qualité décente</span> <span class="caret"></span>
         </button>
+
         <ul class="dropdown-menu">
-            <li><a href="#" id="app-cards-list-validated">Apps officielles seulement</a></li>
-            <li><a href="#" id="app-cards-list-working">Apps "working" seulement</a></li>
-            <li><a href="#" id="app-cards-list-working-inprogress">Apps "in progress"/"not working"</a></li>
-            <li><a href="#" id="app-cards-list-all-apps">Toutes les apps</a></li>
+            <li><a href="#" data-quality-filter="high">Seulement les apps haute-qualité</a></li>
+            <li><a href="#" data-quality-filter="decent">Seulement les apps de qualité décente</a></li>
+            <li><a href="#" data-quality-filter="working">Seulement les apps fonctionelles</a></li>
+            <li><a href="#" data-quality-filter="none">Toutes les apps</a></li>
         </ul>
     </div>
 </div>
 <br />
-<div id="community-app-list-warrant" class="alert alert-danger">
-    <p>Seules les apps marquées <span class="label label-success label-as-badge">validated</span> sont officiellement supportées par l'équipe de développement d'applications. </p>
 
-    <p>Les apps marquées <span class="label label-success label-as-badge">working</span>, <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> sont des applications non officielles maintenues par la communauté, vous pouvez les tester et les utiliser **à vos risques et périls**.</p>
+<!--
+Disclaimers
+-->
 
-    <p>Important: c'est le mainteneur de l'application qui définit son application comme "working" et non pas l'équipe de développement d'applications de Yunohost. Installez ces apps à vos risques et périls. Nous ne fournissons pas de support pour elles.</p>
+<div class="alert alert-info">L'équipe de packaging d'applications sera heureuse de recevoir vos commentaires! Si vous trouvez des problèmes ou des améliorations possibles en installant une app, n'hésitez pas à contribuer en créant un ticket (issue) directement sur le dépôt de code.</div>
+
+<div id="bad-quality-apps-disclaimer" class="alert alert-warning">
+Les applications avec un niveau inférieur ou égal à 4 peuvent fonctionner, mais ne seront pas forcément bien intégrées avec YunoHost, ou bien ne respectent pas les bonnes pratiques de packaging.
 </div>
-<div class="alert alert-info">Les développeurs d'applications apprécieront vos remarques. Si vous installez leurs apps et trouvez des dysfonctionnement, ou si vous avez des idées d'amélioration, n'hésitez pas à créer des tickets directement sur les pages de dépots des projets.</div>
 
-<div class="app-cards-list" id="app-cards-list"></div>
+<div id="broken-apps-disclaimer" class="alert alert-danger">
+Les applications niveau 0, ou étiquettées <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> sont toujours en cours de packaging ou sont connues pour être cassées. **Ne les installez pas** sur un serveur de production!
+</div>
 
-<div class="alert alert-warning">Si vous ne trouvez pas l'application que vous recherchez, vous pouvez la rechercher dans les apps communautaires (working, inprogress et notworking) ou remplir la <a href="/apps_wishlist_fr">liste d'apps souhaitées</a>.</div>
+<div id="app-cards-list" class="app-cards-list"></div>
+
+<div class="alert alert-warning">Si vous ne trouvez pas une application précise que vous recherchez, vous pouvez chercher un dépôt nommé nomdelapp_ynh sur Github ou internet, ou bien l'ajouter à la <a href="/apps_wishlist">liste d'apps souhaitées</a>.</div>
+
+<!--
+Custom CSS for this page
+-->
 
 <style>
 /*=================================================
@@ -64,6 +78,7 @@ Cette page requiert que Javascript soit activé pour s'afficher correctement :s.
     min-height: 1px;
     margin-right: 10px;
     margin-left: 10px;
+    border-radius: 3px;
 }
 /*===============================================*/
 
@@ -75,18 +90,27 @@ Cette page requiert que Javascript soit activé pour s'afficher correctement :s.
     margin-bottom:5px;
     font-size:1.2em;
 }
-.app-card .category {
+.app-card .app-badges {
     height:35px;
 }
-.app-card .category .label, .app-card-date-maintainer {
-    font-size:0.7em;
+.app-card .app-badges .label, .app-card-date-maintainer {
+    font-size:0.6em;
 }
+
+.label-epic {
+    background-color: darkorchid;
+}
+
 .app-card-date-maintainer {
     text-align:right;
     max-height: 18px;
     margin-bottom: 3px;
     margin-right: 7px;
     margin-top: -5px;
+}
+
+.app-card .unmaintained {
+   color: #e0aa33;
 }
 
 .app-card-desc {
@@ -104,8 +128,10 @@ Cette page requiert que Javascript soit activé pour s'afficher correctement :s.
 }
 .app-card > .btn-group > .btn{
     border-bottom:0;
+    font-size: 0.9em;
+    line-height: 1.58;
 }
-.app-card > .btn-group > .btn:first-child {   
+.app-card > .btn-group > .btn:first-child {
     border-left:0;
     border-top-left-radius:0;
 }
@@ -118,30 +144,38 @@ Cette page requiert que Javascript soit activé pour s'afficher correctement :s.
 /*===============================================*/
 </style>
 
+<!--
+App card template
+-->
+
 <script type="text/template" id="app-template2">
-    <div class="app-card_{app_id} app-card panel panel-default">
+    <div class="app-card_{app_id} app-card panel panel-default" data-quality="{app_quality}">
 
         <div class="panel-body">
             <h3>{app_name}</h3>
-            <div class="category"></div>
+            <div class="app-badges"></div>
 
             <div class="app-card-desc">{app_description}</div>
         </div>
-
             <div class="app-card-date-maintainer">
-                <span class="glyphicon glyphicon-refresh"></span> {app_update} - 
-                <span class="glyphicon glyphicon-user"></span> {app_maintainer}
+                <span class="glyphicon glyphicon-refresh"></span> {app_update} -
+                <span title="{maintained_help}" class="{maintained_state}"><span class="glyphicon glyphicon-{maintained_icon}"></span> {app_maintainer}</span>
             </div>
         <div class="btn-group" role="group">
             <a href="{app_git}" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> Code</a>
-            <a href="#/app_{app_id}_fr" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> Doc</a>
-            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_bootstrap} col-sm-4 active">Installer</a>
+            <a href="#/app_{app_id}_en" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> Doc</a>
+            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_css_style} col-sm-4 active"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Installer</a>
         </div>
 
-    </div> 
+    </div>
 </script>
 
+<!--
+Javascript helpers
+-->
+
 <script>
+
 function timeConverter(UNIX_timestamp) {
     var a = new Date(UNIX_timestamp*1000);
     var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
@@ -156,19 +190,36 @@ function timeConverter(UNIX_timestamp) {
     return time;
 }
 
+
 $(document).ready(function () {
-    // Hide warrant about community list
-    $('#community-app-list-warrant').hide();
-    var filters = ["validated"];
+
+    // Hide warrant about states when we're using the default filter
+    $('#state-disclaimer').hide();
+    var quality_filters = "decent";
 
     function filter(){
-        var filters_text = filters.map(function(el) { return '.app-' + el;}).join(', ');
-        var valThis = $('#filter-app-cards').val().toLowerCase();
-        $('.app-card').each(function(){
-            var text = $(this).find('h3').text().toLowerCase();
-            (text.indexOf(valThis) >= 0 && $(this).find(filters_text).length > 0) ? $(this).show() : $(this).hide();
+
+        var current_quality_filter = $('#current-quality-filter').data("filter");
+        var user_input_in_search_field = $('#filter-app-cards').val().toLowerCase();
+
+        $('.app-card').each(function() {
+            // This is where we actually define how apps are filtered:
+            // we look for the name of the app (h3) and try to find the user input
+            // + we check this app match the current quality filter
+            var app_name = $(this).find('h3').text().toLowerCase();
+            if (app_name.indexOf(user_input_in_search_field) >= 0 && $(this).data("quality").indexOf(current_quality_filter) >= 0)
+            {
+                $(this).show();
+            }
+            else
+            {
+                $(this).hide();
+            }
         });
-        (filters.indexOf("working") == -1) ?$('#community-app-list-warrant').hide():$('#community-app-list-warrant').show();
+
+        // Display or hide the disclaimers depending on the current filter...
+        ((current_quality_filter == "working") || (current_quality_filter == "none")) ? $("#bad-quality-apps-disclaimer").show() : $("#bad-quality-apps-disclaimer").hide();
+        ((current_quality_filter == "none")) ? $("#broken-apps-disclaimer").show() : $("#broken-apps-disclaimer").hide();
     }
 
     //=================================================
@@ -176,81 +227,88 @@ $(document).ready(function () {
     //=================================================
     $('#filter-app-cards').keyup(filter);
 
-    $('#app-cards-list-validated').click(function(){
-        filters = ["validated"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-validated').text());
+    $('a[data-quality-filter]').on("click", function(){
+        $('#current-quality-filter').text($(this).text());
+        $('#current-quality-filter').data("filter", $(this).data("quality-filter"));
         filter();
     });
-
-    $('#app-cards-list-working').click(function(){
-        filters = ["validated", "working"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working').text());
-        filter();
-    });
-
-    $('#app-cards-list-working-inprogress').click(function(){
-        filters = ["notworking", "inprogress"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working-inprogress').text());
-        filter();
-    });
-
-    $('#app-cards-list-all-apps').click(function(){
-        filters = ["validated", "working", "inprogress", "notworking"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-all-apps').text());
-        filter();
-    }); 
-    //=================================================  
-
+    
+    filter();
 
     //=================================================
     // Upload apps lists
     //=================================================
-    var app_list={};
-    $.when(
-        $.getJSON('https://app.yunohost.org/community.json', {}, function(community) {
-            app_list.community = $.map(community, function(el) { return el; });
-        }),
-        $.getJSON('https://app.yunohost.org/official.json', {}, function(official) {
-            app_list.official = $.map(official, function(el) { return el; });
-        })
-    ).then(function() {
-        app_list = app_list.official.concat(app_list.community);
-    
-        // Sort alpha
-        app_list.sort(function(a, b){
-            a_state = (a.state == "validated")?4:(a.state == "working")?3:(a.state == "inprogress")?2:1;
-            b_state = (b.state == "validated")?4:(b.state == "working")?3:(b.state == "inprogress")?2:1;
+    var catalog = undefined;
+
+    // Fetch application catalog
+
+    $.getJSON('https://app.yunohost.org/apps.json', {}, function(data) {
+
+        catalog = $.map(data, function(el) { return el; });
+
+        // Clarify high quality state, and level if undefined or inprogress or notworking...
+
+        $.each(catalog, function(k, infos) {
+            if ((infos.level === undefined) || (infos.state === "inprogress") || (infos.state === "notworking")) {
+                infos.level = null;
+            }
+            if ((infos.high_quality === true) && (infos.level === 8)) {
+                infos.state = "high quality";
+            }
+        });
+
+        // Sort apps according to their state and level...
+
+        catalog.sort(function(a, b){
+            a_state = (a.state === "high quality")?4:(a.level > 4)?3:(a.state > 0)?2:1;
+            b_state = (b.state === "high quality")?4:(b.level > 4)?3:(b.state > 0)?2:1;
             if (a_state < b_state || a_state == b_state && a.level < b.level || a_state == b_state && a.level == b.level && a.manifest.id > b.manifest.id) {return 1;}
             else if (a.manifest.id == b.manifest.id) {return 0;}
             return -1;
         });
-        $.each(app_list, function(k, infos) {
+
+        // Add the card for each app
+
+        $.each(catalog, function(k, infos) {
+
             app_id = infos.manifest.id;
-            app_install_bootstrap = "success";
-            if (infos.state === "validated") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "working") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "inprogress") {
-                app_state_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.state === "notworking") {
-                app_state_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            }
-            if (infos.level == null ) {
-                infos.level = '?';
-            }
-            if (infos.level == 0 ) {
-                app_level_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            } else if (infos.level <= 2) {
-                app_level_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.level >= 7) {
-                app_level_bootstrap = "success";
+
+            // Define what style to use for state, level and install button
+            // according to the app quality ....
+
+            if (infos.state === "high quality") {
+                app_quality = "high,decent,working,none";
+                app_state_css_style = "epic";
+                app_install_css_style = "success";
+                app_level_css_style = "epic";
+            } else if (infos.level > 4) {
+                app_quality = "decent,working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "success";
+                app_level_css_style = "success";
+            } else if (infos.level > 0) {
+                app_quality = "working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "warning";
+                app_level_css_style = "warning";
             } else {
-                app_level_bootstrap = "default";
+                app_quality = "none";
+                if (infos.state === "working") {
+                    app_state_css_style = "success";
+                }
+                else if (infos.state === "inprogress") {
+                    app_state_css_style = "warning";
+                }
+                else {
+                    app_state_css_style = "danger";
+                }
+                app_install_css_style = "danger";
+                app_level_css_style = "danger";
+            }
+
+            // If level is null, we wanna display '?'
+            if (infos.level == null) {
+                infos.level = '?';
             }
 
             // Fill the template
@@ -261,35 +319,49 @@ $(document).ready(function () {
              .replace(/{app_git}/g, infos.git.url)
              .replace('{app_branch}', infos.git.branch)
              .replace('{app_level}', infos.level)
+             .replace('{app_quality}', app_quality)
              .replace('{app_update}', timeConverter(infos.lastUpdate))
-             .replace('{app_state_bootstrap}', app_state_bootstrap)
-             .replace('{app_install_bootstrap}', app_install_bootstrap);
+             .replace('{app_state_css_style}', app_state_css_style)
+             .replace('{app_install_css_style}', app_install_css_style);
 
-            if (infos.manifest.developer) {
-                html = html
-                 .replace('{app_maintainer}', infos.manifest.developer.name)
-                 .replace('{app_mail}', infos.manifest.developer.email);
+            // Handle the maintainer info
+            if (infos.maintained == false)
+            {
+               html = html
+                 .replace('{maintained_state}', 'unmaintained')
+                 .replace('{maintained_icon}', 'warning-sign')
+                 .replace('{app_maintainer}', "Unmaintained")
+                 .replace('{maintained_help}', "This package is currently unmaintained. Feel free to propose yourself as the new maintainer !");
             }
-
-            if (infos.manifest.maintainer) {
+            else {
                 html = html
-                 .replace('{app_maintainer}', infos.manifest.maintainer.name)
-                 .replace('{app_mail}', infos.manifest.maintainer.email);
+                 .replace('{maintained_state}', 'maintained')
+                 .replace('{maintained_icon}', 'user')
+                 .replace('{maintained_help}', "Current maintainer of this package");
+
+                if ((infos.manifest.developer) && (infos.manifest.developer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.developer.name);
+                }
+                else if ((infos.manifest.maintainer) && (infos.manifest.maintainer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.maintainer.name);
+                }
+                else {
+                    html = html.replace('{app_maintainer}', "???");
+                }
             }
 
             // Fill the template
             $('#app-cards-list').append(html);
             $('.app-card_'+ app_id).attr('id', 'app-card_'+ app_id);
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_level_bootstrap+' label-as-badge">'+infos.level+'</span>');
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_state_bootstrap+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
-            if (infos.manifest.license && infos.manifest.license != 'free') {
-                $('.app-card_'+ app_id + ' .category').append(' <span class="label label-default">'+infos.manifest.license+'</span>');
+            $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_state_css_style+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
+            if ((infos.state === "high quality") || (infos.state === "working")) {
+                $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_level_css_style+' label-as-badge">niveau '+infos.level+'</span>');
             }
 
         });
+
         filter();
     });
-    //=================================================  
+    //=================================================
 });
 </script>
-

--- a/apps_it.md
+++ b/apps_it.md
@@ -1,39 +1,54 @@
-# Apps
+# Application catalog
 
 <span class="javascriptDisclaimer">
-Questa pagina richiede Javascript abilitato per essere correttamente mostrata :s.
+This page requires Javascript enabled to display properly :s.
 <br/>
 <br/>
 </span>
 
+<!--
+Search bar
+-->
+
 <div class="input-group">
-    <span class="input-group-addon" id="basic-addon1"><span class="glyphicon glyphicon-search"></span></span>
-    <input type="text" id="filter-app-cards" class="form-control"  placeholder="Search for apps..." aria-describedby="basic-addon1"/>
+    <span id="basic-addon1" class="input-group-addon" ><span class="glyphicon glyphicon-search"></span></span>
+    <input id="filter-app-cards" type="text" class="form-control"  placeholder="Search for apps..." aria-describedby="basic-addon1"/>
     <div class="input-group-btn">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <span id="app-cards-list-filter-text">Solo app ufficiali</span> <span class="caret"></span>
+            <span id="current-quality-filter" data-filter="decent">Only decent quality apps</span> <span class="caret"></span>
         </button>
+
         <ul class="dropdown-menu">
-            <li><a href="#" id="app-cards-list-validated">Solo app ufficiali</a></li>
-            <li><a href="#" id="app-cards-list-working">Solo app funzionanti</a></li>
-            <li><a href="#" id="app-cards-list-working-inprogress">App in sviluppo/non funzionanti</a></li>
-            <li><a href="#" id="app-cards-list-all-apps">Tutte le app</a></li>
+            <li><a href="#" data-quality-filter="high">Only high quality apps</a></li>
+            <li><a href="#" data-quality-filter="decent">Only decent quality apps</a></li>
+            <li><a href="#" data-quality-filter="working">Only working apps</a></li>
+            <li><a href="#" data-quality-filter="none">All apps</a></li>
         </ul>
     </div>
 </div>
 <br />
-<div id="community-app-list-warrant" class="alert alert-danger">
-    <p>Solo le app etichettate come <span class="label label-success label-as-badge">validate</span> sono ufficialmente supportate dalla squadra di packaging. </p>
 
-    <p>App etichettate come <span class="label label-success label-as-badge">funzionanti</span>, <span class="label label-warning label-as-badge">insviluppo</span>, <span class="label label-danger label-as-badge">nonfunzionanti</span> arrivano dai repository della comunità, puoi provare ed utilizzarle **a tuo rischio e pericolo**.</p>
+<!--
+Disclaimers
+-->
 
-    <p>Importante: è il mantenitore dell'applicazione che indica l'applicazione come funzionante, non il team base di YunoHost. Installale a tuo rischio e pericolo. Noi non forniamo supporto per queste app.</p>
+<div class="alert alert-info">The application packaging team will welcome your feedback! If you install an app and find issues or possible improvements, do not hesitate to contribute by reporting your issues directly on the code repositories.</div>
+
+<div id="bad-quality-apps-disclaimer" class="alert alert-warning">
+    Applications with a level below or equal to 4 may be working, but they might be not well-integrated with YunoHost, or they do not respect the recommended packaging practices.
 </div>
-<div class="alert alert-info">I mantenitori apprezzeranno i tuoi consigli.Se le installi e incontri dei problemi, o idee per migliorarle, non esitare a segnalare la cosa direttamente nei rispettivi repository.</div>
 
-<div class="app-cards-list" id="app-cards-list"></div>
+<div id="broken-apps-disclaimer" class="alert alert-danger">
+    Applications with level 0, or flagged as <span class="label label-warning label-as-badge">inprogress</span>, <span class="label label-danger label-as-badge">notworking</span> are still in development or are know to not be working. **Do not install them** in a production environment!
+</div>
 
-<div class="alert alert-warning">Se non trovi l'app che stai cercando, puoi provarla a cercarla nel repository delle app della comunità (funzionanti, in sviluppo, non funzionanti) o aggiungila alla <a href="/apps_wishlist_en">lista delle app dei desideri</a>.</div>
+<div id="app-cards-list" class="app-cards-list"></div>
+
+<div class="alert alert-warning">If you don't find the app you are looking for, you can try to look for a appname_ynh repository on Github or on the internet, or add it to the <a href="/apps_wishlist_en">apps wishlist</a>.</div>
+
+<!--
+Custom CSS for this page
+-->
 
 <style>
 /*=================================================
@@ -64,6 +79,7 @@ Questa pagina richiede Javascript abilitato per essere correttamente mostrata :s
     min-height: 1px;
     margin-right: 10px;
     margin-left: 10px;
+    border-radius: 3px;
 }
 /*===============================================*/
 
@@ -75,12 +91,17 @@ Questa pagina richiede Javascript abilitato per essere correttamente mostrata :s
     margin-bottom:5px;
     font-size:1.2em;
 }
-.app-card .category {
+.app-card .app-badges {
     height:35px;
 }
-.app-card .category .label, .app-card-date-maintainer {
-    font-size:0.7em;
+.app-card .app-badges .label, .app-card-date-maintainer {
+    font-size:0.6em;
 }
+
+.label-epic {
+    background-color: darkorchid;
+}
+
 .app-card-date-maintainer {
     text-align:right;
     max-height: 18px;
@@ -108,6 +129,8 @@ Questa pagina richiede Javascript abilitato per essere correttamente mostrata :s
 }
 .app-card > .btn-group > .btn{
     border-bottom:0;
+    font-size: 0.9em;
+    line-height: 1.58;
 }
 .app-card > .btn-group > .btn:first-child {
     border-left:0;
@@ -122,12 +145,16 @@ Questa pagina richiede Javascript abilitato per essere correttamente mostrata :s
 /*===============================================*/
 </style>
 
+<!--
+App card template
+-->
+
 <script type="text/template" id="app-template2">
-    <div class="app-card_{app_id} app-card panel panel-default">
+    <div class="app-card_{app_id} app-card panel panel-default" data-quality="{app_quality}">
 
         <div class="panel-body">
             <h3>{app_name}</h3>
-            <div class="category"></div>
+            <div class="app-badges"></div>
 
             <div class="app-card-desc">{app_description}</div>
         </div>
@@ -136,18 +163,23 @@ Questa pagina richiede Javascript abilitato per essere correttamente mostrata :s
                 <span title="{maintained_help}" class="{maintained_state}"><span class="glyphicon glyphicon-{maintained_icon}"></span> {app_maintainer}</span>
             </div>
         <div class="btn-group" role="group">
-            <a href="{app_git}" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> Codice</a>
+            <a href="{app_git}" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-globe" aria-hidden="true"></span> Code</a>
             <a href="#/app_{app_id}_en" target="_BLANK" type="button" class="btn btn-default col-sm-4"><span class="glyphicon glyphicon-book" aria-hidden="true"></span> Doc</a>
-            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_bootstrap} col-sm-4 active"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Installa</a>
+            <a href="https://install-app.yunohost.org/?app={app_id}" target="_BLANK" type="button" class="btn btn-{app_install_css_style} col-sm-4 active"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Install</a>
         </div>
 
     </div>
 </script>
 
+<!--
+Javascript helpers
+-->
+
 <script>
+
 function timeConverter(UNIX_timestamp) {
     var a = new Date(UNIX_timestamp*1000);
-    var months = ['Gennaio','Febbraio','Marzo','Aprile','Maggio','Giugno','Luglio','Agosto','Settembre','Ottobre','Novembre','Dicembre'];
+    var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
     var year = a.getFullYear();
     var month = months[a.getMonth()];
     var date = a.getDate();
@@ -159,19 +191,36 @@ function timeConverter(UNIX_timestamp) {
     return time;
 }
 
+
 $(document).ready(function () {
-    // Hide warrant about community list
-    $('#community-app-list-warrant').hide();
-    var filters = ["validated"];
+
+    // Hide warrant about states when we're using the default filter
+    $('#state-disclaimer').hide();
+    var quality_filters = "decent";
 
     function filter(){
-        var filters_text = filters.map(function(el) { return '.app-' + el;}).join(', ');
-        var valThis = $('#filter-app-cards').val().toLowerCase();
-        $('.app-card').each(function(){
-            var text = $(this).find('h3').text().toLowerCase();
-            (text.indexOf(valThis) >= 0 && $(this).find(filters_text).length > 0) ? $(this).show() : $(this).hide();
+
+        var current_quality_filter = $('#current-quality-filter').data("filter");
+        var user_input_in_search_field = $('#filter-app-cards').val().toLowerCase();
+
+        $('.app-card').each(function() {
+            // This is where we actually define how apps are filtered:
+            // we look for the name of the app (h3) and try to find the user input
+            // + we check this app match the current quality filter
+            var app_name = $(this).find('h3').text().toLowerCase();
+            if (app_name.indexOf(user_input_in_search_field) >= 0 && $(this).data("quality").indexOf(current_quality_filter) >= 0)
+            {
+                $(this).show();
+            }
+            else
+            {
+                $(this).hide();
+            }
         });
-        (filters.indexOf("working") == -1) ?$('#community-app-list-warrant').hide():$('#community-app-list-warrant').show();
+
+        // Display or hide the disclaimers depending on the current filter...
+        ((current_quality_filter == "working") || (current_quality_filter == "none")) ? $("#bad-quality-apps-disclaimer").show() : $("#bad-quality-apps-disclaimer").hide();
+        ((current_quality_filter == "none")) ? $("#broken-apps-disclaimer").show() : $("#broken-apps-disclaimer").hide();
     }
 
     //=================================================
@@ -179,81 +228,88 @@ $(document).ready(function () {
     //=================================================
     $('#filter-app-cards').keyup(filter);
 
-    $('#app-cards-list-validated').click(function(){
-        filters = ["validated"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-validated').text());
+    $('a[data-quality-filter]').on("click", function(){
+        $('#current-quality-filter').text($(this).text());
+        $('#current-quality-filter').data("filter", $(this).data("quality-filter"));
         filter();
     });
 
-    $('#app-cards-list-working').click(function(){
-        filters = ["validated", "working"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working').text());
-        filter();
-    });
-
-    $('#app-cards-list-working-inprogress').click(function(){
-        filters = ["notworking", "inprogress"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-working-inprogress').text());
-        filter();
-    });
-
-    $('#app-cards-list-all-apps').click(function(){
-        filters = ["validated", "working", "inprogress", "notworking"];
-        $('#app-cards-list-filter-text').text($('#app-cards-list-all-apps').text());
-        filter();
-    });
-    //=================================================
-
+    filter();
 
     //=================================================
     // Upload apps lists
     //=================================================
-    var app_list={};
-    $.when(
-        $.getJSON('https://app.yunohost.org/community.json', {}, function(community) {
-            app_list.community = $.map(community, function(el) { return el; });
-        }),
-        $.getJSON('https://app.yunohost.org/official.json', {}, function(official) {
-            app_list.official = $.map(official, function(el) { return el; });
-        })
-    ).then(function() {
-        app_list = app_list.official.concat(app_list.community);
+    var catalog = undefined;
 
-        // Sort alpha
-        app_list.sort(function(a, b){
-            a_state = (a.state == "validated")?4:(a.state == "working")?3:(a.state == "inprogress")?2:1;
-            b_state = (b.state == "validated")?4:(b.state == "working")?3:(b.state == "inprogress")?2:1;
+    // Fetch application catalog
+
+    $.getJSON('https://app.yunohost.org/apps.json', {}, function(data) {
+
+        catalog = $.map(data, function(el) { return el; });
+
+        // Clarify high quality state, and level if undefined or inprogress or notworking...
+
+        $.each(catalog, function(k, infos) {
+            if ((infos.level === undefined) || (infos.state === "inprogress") || (infos.state === "notworking")) {
+                infos.level = null;
+            }
+            if ((infos.high_quality === true) && (infos.level === 8)) {
+                infos.state = "high quality";
+            }
+        });
+
+        // Sort apps according to their state and level...
+
+        catalog.sort(function(a, b){
+            a_state = (a.state === "high quality")?4:(a.level > 4)?3:(a.state > 0)?2:1;
+            b_state = (b.state === "high quality")?4:(b.level > 4)?3:(b.state > 0)?2:1;
             if (a_state < b_state || a_state == b_state && a.level < b.level || a_state == b_state && a.level == b.level && a.manifest.id > b.manifest.id) {return 1;}
             else if (a.manifest.id == b.manifest.id) {return 0;}
             return -1;
         });
-        $.each(app_list, function(k, infos) {
+
+        // Add the card for each app
+
+        $.each(catalog, function(k, infos) {
+
             app_id = infos.manifest.id;
-            app_install_bootstrap = "success";
-            if (infos.state === "validated") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "working") {
-                app_state_bootstrap = "success";
-            } else if (infos.state === "inprogress") {
-                app_state_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.state === "notworking") {
-                app_state_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            }
-            if (infos.level == null ) {
-                infos.level = '?';
-            }
-            if (infos.level == 0 ) {
-                app_level_bootstrap = "danger";
-                app_install_bootstrap = "danger";
-            } else if (infos.level <= 2) {
-                app_level_bootstrap = "warning";
-                app_install_bootstrap = "danger";
-            } else if (infos.level >= 7) {
-                app_level_bootstrap = "success";
+
+            // Define what style to use for state, level and install button
+            // according to the app quality ....
+
+            if (infos.state === "high quality") {
+                app_quality = "high,decent,working,none";
+                app_state_css_style = "epic";
+                app_install_css_style = "success";
+                app_level_css_style = "epic";
+            } else if (infos.level > 4) {
+                app_quality = "decent,working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "success";
+                app_level_css_style = "success";
+            } else if (infos.level > 0) {
+                app_quality = "working,none";
+                app_state_css_style = "success";
+                app_install_css_style = "warning";
+                app_level_css_style = "warning";
             } else {
-                app_level_bootstrap = "default";
+                app_quality = "none";
+                if (infos.state === "working") {
+                    app_state_css_style = "success";
+                }
+                else if (infos.state === "inprogress") {
+                    app_state_css_style = "warning";
+                }
+                else {
+                    app_state_css_style = "danger";
+                }
+                app_install_css_style = "danger";
+                app_level_css_style = "danger";
+            }
+
+            // If level is null, we wanna display '?'
+            if (infos.level == null) {
+                infos.level = '?';
             }
 
             // Fill the template
@@ -264,45 +320,47 @@ $(document).ready(function () {
              .replace(/{app_git}/g, infos.git.url)
              .replace('{app_branch}', infos.git.branch)
              .replace('{app_level}', infos.level)
+             .replace('{app_quality}', app_quality)
              .replace('{app_update}', timeConverter(infos.lastUpdate))
-             .replace('{app_state_bootstrap}', app_state_bootstrap)
-             .replace('{app_install_bootstrap}', app_install_bootstrap);
+             .replace('{app_state_css_style}', app_state_css_style)
+             .replace('{app_install_css_style}', app_install_css_style);
 
+            // Handle the maintainer info
             if (infos.maintained == false)
             {
                html = html
                  .replace('{maintained_state}', 'unmaintained')
                  .replace('{maintained_icon}', 'warning-sign')
-                 .replace('{app_maintainer}', "Non mantenuto")
-                 .replace('{maintained_help}', "Questo pacchetto attualmente non è mantenuto. Sentiti libero di proporti come nuovo mantenitore !");
-            } else {
-            if (infos.manifest.developer) {
+                 .replace('{app_maintainer}', "Unmaintained")
+                 .replace('{maintained_help}', "This package is currently unmaintained. Feel free to propose yourself as the new maintainer !");
+            }
+            else {
                 html = html
                  .replace('{maintained_state}', 'maintained')
                  .replace('{maintained_icon}', 'user')
-                 .replace('{app_maintainer}', infos.manifest.developer.name)
-                 .replace('{maintained_help}', "Mantenitore attuale di questo pacchetto");
-            }
-            if (infos.manifest.maintainer) {
-                html = html
-                 .replace('{maintained_state}', 'maintained')
-                 .replace('{maintained_icon}', 'user')
-                 .replace('{app_maintainer}', infos.manifest.maintainer.name)
-                 .replace('{maintained_help}', "Mantenitore attuale di questo pacchetto");;
-            }
-            }
+                 .replace('{maintained_help}', "Current maintainer of this package");
 
+                if ((infos.manifest.developer) && (infos.manifest.developer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.developer.name);
+                }
+                else if ((infos.manifest.maintainer) && (infos.manifest.maintainer.name)) {
+                    html = html.replace('{app_maintainer}', infos.manifest.maintainer.name);
+                }
+                else {
+                    html = html.replace('{app_maintainer}', "???");
+                }
+            }
 
             // Fill the template
             $('#app-cards-list').append(html);
             $('.app-card_'+ app_id).attr('id', 'app-card_'+ app_id);
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_level_bootstrap+' label-as-badge">'+infos.level+'</span>');
-            $('.app-card_'+ app_id + ' .category').append(' <span class="label label-'+app_state_bootstrap+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
-            if (infos.manifest.license && infos.manifest.license != 'free') {
-                $('.app-card_'+ app_id + ' .category').append(' <span class="label label-default">'+infos.manifest.license+'</span>');
+            $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_state_css_style+' label-as-badge app-'+infos.state+'">'+infos.state+'</span>');
+            if ((infos.state === "high quality") || (infos.state === "working")) {
+                $('.app-card_'+ app_id + ' .app-badges').append(' <span class="label label-'+app_level_css_style+' label-as-badge">level '+infos.level+'</span>');
             }
 
         });
+
         filter();
     });
     //=================================================

--- a/index.md
+++ b/index.md
@@ -75,7 +75,7 @@
   <div class="row cf">
     <div class="col-md-7 text-right">
       <h1>Install <small>applications to build your little corner of Internet</small></h1>
-      <p><br /><a href="/apps">Browse available apps</a></p>
+      <p><br /><a href="/apps">Browse the app catalog</a></p>
     </div>
     <div class="col-md-4">
       <div class="feature-pic">

--- a/index_fr.md
+++ b/index_fr.md
@@ -72,7 +72,7 @@
   <div class="row cf">
     <div class="col-md-7 text-right">
       <h1>Construisez <small>votre petit bout d'Internet en ajoutant des applications en quelques clics</small></h1>
-      <p><br /><a href="/apps">Parcourir les applications disponibles</a></p>
+      <p><br /><a href="/apps">Parcourir le catalogue d'applications</a></p>
     </div>
     <div class="col-md-4">
       <div class="feature-pic">


### PR DESCRIPTION
Despite @yalh76 being a sweetheart trying to not give me work, his PR reminded me that the current app catalog view in the doc gotta be updated :sweat_smile:  following the drop of official apps and so on (kinda started in https://github.com/YunoHost/doc/pull/960 but many other things to do to clean the code and match what's in the admin)

Anyway here are some screenshot to compare before/after (well, more like after/before) though anyway you can copy-pasta the code in the Edit mode of Simone to try it yourself

I can easily retranslate the page for the french version, but dunno yet what to do about the other translations...

### View with the default filter when you arrive on the page

![2019-10-18-005152_1366x768_scrot](https://user-images.githubusercontent.com/4533074/67054115-c1522600-f143-11e9-892e-16d4900cde97.png)

### With "all apps" filter, showing the disclaimers

![2019-10-18-005246_1366x768_scrot](https://user-images.githubusercontent.com/4533074/67054107-bd260880-f143-11e9-98f2-f3da37905d0b.png)

### Filtering with "co" to see various card / apps types

![2019-10-18-010350_1366x768_scrot](https://user-images.githubusercontent.com/4533074/67054145-d5962300-f143-11e9-860a-9bf2013cf615.png)


