### PR TITLE
Fix app pages

### DIFF
--- a/app_gogs_fr.md
+++ b/app_gogs_fr.md
@@ -10,4 +10,3 @@ Pour utiliser pleinement la puissance de gogs vous devez avoir appréhender ce q
  - [Site Officiel - gogs.io](https://gogs.io)
  - [Dépot applications gogs pour YunoHost](https://github.com/YunoHost-Apps/gogs_ynh)
  - [Site officiel de l'outils git - git-scm.com](https://git-scm.com/)
- - [Trouver de l'aide et poser toutes vos questions : forum.yunohost.org](https://forum.yunohost.org/c/support/apps)

--- a/app_gogs_fr.md
+++ b/app_gogs_fr.md
@@ -6,7 +6,7 @@ Gogs est une forge logiciel minimaliste utilisant git. Gogs a été conçu pour 
 Il est donc adapté à l'auto-hébergement d'une forge git.
 Pour utiliser pleinement la puissance de gogs vous devez avoir appréhender ce qu'est git et l'utilisation d'un [logiciel de gestion de versions](https://fr.wikipedia.org/wiki/Logiciel_de_gestion_de_versions).
 
-## <a name=LiensUtiles>Liens utiles</a>
+## Liens utiles
  - [Site Officiel - gogs.io](https://gogs.io)
  - [Dépot applications gogs pour YunoHost](https://github.com/YunoHost-Apps/gogs_ynh)
  - [Site officiel de l'outils git - git-scm.com](https://git-scm.com/)

--- a/app_nextcloud.md
+++ b/app_nextcloud.md
@@ -167,4 +167,3 @@ Save and clean your caches (Cloudflare, browser,...) and that's it.
 
  - Official website : [nextcloud.com](https://nextcloud.com/)  
  - Application catalogue for nextcloud : [apps.nextcloud.com](https://apps.nextcloud.com/)  
- - Find help and ask all your questions : [forum.yunohost.org](https://forum.yunohost.org/c/support)  

--- a/app_nextcloud.md
+++ b/app_nextcloud.md
@@ -9,18 +9,18 @@
 
 Nextcloud is a file hosting service, many applications can be installed to offer it new features such as a calendar, a directory, notes and many others (you can find some applications in the [third-party applications](#AppsTiers) part  but there are many others depending on your needs).
 
-## Discovering the Nextcloud environment <a name="EnvironmentNextcloud"></a>
+## Discovering the Nextcloud environment <a name="EnvironmentNextcloud" href=""></a>
 
 Due to the creation of Nextcloud, a database with third-party applications to install, this chapter will only concern the nextcloud database without added applications. More information on applications in the dedicated section or in the nextcloud application catalogue: [apps.nextcloud.com](https://apps.nextcloud.com).  
 Nextcloud is before a cloud service (like Seafile and others), it allows synchronization and file sharing on the Internet and between several terminals (computers, smartphone) but also with several people. 
 
-## Mobile and computer client software <a name="ClientSoftware"></a>
+## Mobile and computer client software <a name="ClientSoftware" href=""></a>
 
 There are client software for all platforms. You can find them on the official nextcloud website: https://nextcloud.com/install/#install-clients
 
-## Useful Manipulations & Problems Encountered <a name="UtileManipulations"></a>
+## Useful Manipulations & Problems Encountered <a name="UtileManipulations" href=""></a>
 
-### Add storage space <a name="AddSpace"></a>
+### Add storage space <a name="AddSpace" href=""></a>
 
 Solution I. allows you to add a link to a local or remote folder.  
 Solution II. allows to move the main storage space of nextcloud.
@@ -156,16 +156,15 @@ The options to disable (Off) are:
 
 Save and clean your caches (Cloudflare, browser,...) and that's it.
 
-## Third Party Applications <a name="AppsTiers"></a>
+## Third Party Applications <a name="AppsTiers" href=""></a>
 
  - [Calendrier](app_nextcloud_calendar)
  - [contact](app_nextcloud_contact)
  - [KeeWeb](app_nextcloud_keeweb)
  - [Carnet](app_nextcloud_carnet)
 
-## Useful links <a name="UsefulLinks"></a>
+## Useful links <a name="UsefulLinks" href=""></a>
 
  - Official website : [nextcloud.com](https://nextcloud.com/)  
  - Application catalogue for nextcloud : [apps.nextcloud.com](https://apps.nextcloud.com/)  
  - Find help and ask all your questions : [forum.yunohost.org](https://forum.yunohost.org/c/support)  
-

--- a/app_nextcloud_fr.md
+++ b/app_nextcloud_fr.md
@@ -9,18 +9,18 @@
 
 Nextcloud est un service d'hébergement de fichiers, de nombreuses applications peuvent être installées afin de lui offrir de nouvelles fonctionnalités tel qu'un agenda, un répertoire de contacts, des notes et pleins d'autres possibles (vous pouvez trouver quelques applications dans la partie [applications tiers](#AppsTiers) mais il en existe une multitude suivant vos besoins).
 
-## Découverte de l'environnement de Nextcloud<a name="EnvironnementNextcloud"></a>
+## Découverte de l'environnement de Nextcloud<a name="EnvironnementNextcloud" href=""></a>
 
 Du fait de la constitution de Nextcloud, une base avec des applications tiers à installer, ce chapitre ne concernera que la base de nextcloud sans applications ajoutés. Plus d'informations sur les applications dans la partie dédiée ou sur le catalogue d'application de nextcloud : [apps.nextcloud.com](https://apps.nextcloud.com).  
 Nextcloud est avant tout un service de cloud (comme Seafile et d'autres logiciels), il permet une synchronisation et le partage de fichiers sur internet et entre plusieurs terminaux (ordinateurs, smartphone) mais aussi avec plusieurs personnes.
 
-## Logiciels Clients<a name="LogicielsClients"></a>
+## Logiciels Clients<a name="LogicielsClients" href=""></a>
 
 Il existe des logiciels clients pour de nombreux terminaux. Vous pouvez les retrouver sur le site de nextcloud : [nextcloud.com/install/#install-clients](https://nextcloud.com/install/#install-clients)
 
-## Manipulations utiles & problèmes rencontrés<a name="ManipulationsUtiles"></a>
+## Manipulations utiles & problèmes rencontrés<a name="ManipulationsUtiles" href=""></a>
 
-### Ajouter de l'espace à Nextcloud<a name="AjoutEspace"></a>
+### Ajouter de l'espace à Nextcloud<a name="AjoutEspace" href=""></a>
 
 La solution I. permet d'ajouter un lien vers un dossier local ou distant.  
 La solution II. permet de déplacer l'espace de stockage principal de nextcloud.
@@ -156,14 +156,14 @@ Les options à désactiver (Off) sont :
 
 Sauvegarder et nettoyer vos caches (Cloudflare, navigateur, ...) et le tour est joué.
 
-## Applications Tiers<a name="AppsTiers"></a>
+## Applications Tiers<a name="AppsTiers" href=""></a>
 
  + [Calendrier](app_nextcloud_calendar_fr)
  + [contact](app_nextcloud_contact_fr)
  + [KeeWeb](app_nextcloud_keeweb_fr)
  + [Carnet](app_nextcloud_carnet_fr)
 
-## Quelques liens utiles<a name="liensutiles"></a>
+## Quelques liens utiles<a name="liensutiles" href=""></a>
 
 + Site officiel : [nextcloud.com (en)](https://nextcloud.com/)
 + Catalogue d'application pour nextcloud : [apps.nextcloud.com](https://apps.nextcloud.com/)

--- a/app_nextcloud_fr.md
+++ b/app_nextcloud_fr.md
@@ -167,4 +167,3 @@ Sauvegarder et nettoyer vos caches (Cloudflare, navigateur, ...) et le tour est 
 
 + Site officiel : [nextcloud.com (en)](https://nextcloud.com/)
 + Catalogue d'application pour nextcloud : [apps.nextcloud.com](https://apps.nextcloud.com/)
-+ Trouver de l'aide et poser toutes vos questions : [forum.yunohost.org](https://forum.yunohost.org/c/support)

--- a/app_nextcloud_keeweb_fr.md
+++ b/app_nextcloud_keeweb_fr.md
@@ -2,12 +2,8 @@
 
 L'application Keeweb sur le catalogue de nextcloud - [apps.nextcloud.com/keeweb](https://apps.nextcloud.com/apps/keeweb)
 
- - [Manipulations utiles et problèmes rencontrés](#ManipulationsUtiles)
- - [Liens utiles](#liensutiles)
-
 L'application KeeWeb est un gestionnaire de mots de passe incorporé à Nextcloud. Elle permet par exemple de lire un fichier de type KeePass (*.kdbx*) stocké sur votre instance Nextcloud.
 
-## Manipulations utiles & problèmes rencontrés <a name="ManipulationsUtiles"></a>
 Mais il arrive parfois que Nextcloud ne laisse pas l'application prendre en charge ces fichiers, ce qui rend alors impossible leur lecture de KeeWeb. Pour remédier à cela,
 [une solution](https://github.com/jhass/nextcloud-keeweb/issues/34) existe.
 
@@ -34,5 +30,3 @@ Puis ajouter dans ce fichier le texte suivent :
 Enregistrer le fichier (**CTRL** + **o**) et quitter nano (**CTRL** + **c**).
 
 A présent, le problème est corrigé.
-
-## Liens utiles <a name="liensutiles"></a>

--- a/app_peertube_fr.md
+++ b/app_peertube_fr.md
@@ -1,20 +1,16 @@
-#<img src="/images/peertube_logo.png" alt="Logo de PeerTube">  PeerTube
+# <img src="/images/peertube_logo.png" alt="Logo de PeerTube">  PeerTube
 
-**Index**
- - [Découverte de l'environnement de PeerTube](#EnvironnementPeerTube)
- - [Quelques liens utiles](#liensutiles)
 [![Installer PeerTube avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=peertube)
 
 PeerTube est une plateforme de streaming vidéo fédérée (ActivityPub) utilisant P2P (BitTorrent) directement dans le navigateur web, en utilisant WebTorrent.
 
-
-## Découverte de l'environnement de PeerTube <a name ="EnvironnementPeerTube"></a>
+## Découverte de l'environnement de PeerTube
 
 Pour comprendre en quoi PeerTube propose une alternative à youtube, vous êtes invité à regarder le clip réalisé par l'association Framasoft (ci-dessous). Elle est elle même hébergé sur [framatube.org](https://framatube.org)  
 
 <iframe width="560" height="315" sandbox="allow-same-origin allow-scripts" src="https://framatube.org/videos/embed/9db9f3f1-9b54-44ed-9e91-461d262d2205" frameborder="0" allowfullscreen></iframe>
 
-## Quelques liens utiles <a name="liensutiles"></a>
+## Quelques liens utiles
 
  - Site officiel de PeerTube - [joinpeertube.org](https://joinpeertube.org/fr/)
  - Dépot application PeerTube Yunohost - [github.com/YunoHost-Apps/peertube_ynh](https://github.com/YunoHost-Apps/peertube_ynh)

--- a/app_peertube_fr.md
+++ b/app_peertube_fr.md
@@ -14,4 +14,3 @@ Pour comprendre en quoi PeerTube propose une alternative à youtube, vous êtes 
 
  - Site officiel de PeerTube - [joinpeertube.org](https://joinpeertube.org/fr/)
  - Dépot application PeerTube Yunohost - [github.com/YunoHost-Apps/peertube_ynh](https://github.com/YunoHost-Apps/peertube_ynh)
- - Trouver de l'aide et poser toutes vos questions : [forum.yunohost.org](https://forum.yunohost.org/c/support)

--- a/app_pleroma_fr.md
+++ b/app_pleroma_fr.md
@@ -1,15 +1,17 @@
 # <img src="/images/pleroma_logo.png" alt="logo de Pleroma"> Pleroma
 
- - [Découverte de l'interface de Pleroma](#decouvertegeneralepleroma) |
- - [Logiciels Clients pour mobile et ordinateur](#LogicielsClients) |
- - [Liens utiles](#liensutiles) |
+ - [Découverte de l'interface de Pleroma](decouvertegeneralepleroma)
+ - [Logiciels Clients pour mobile et ordinateur](LogicielsClients)
+ - [Liens utiles](liensutiles)
 
 Pleroma est un réseau social décentralisé de micro-blogging qui propose une alternative à Twitter, le protocole Activy Pub qu'il utilise permet d'interagir avec le fediverse composé notamment de Mastodon, GNU Social, et d'autres. Il a l'avantage d'être plus léger que mastodon et se prête donc plus facilement à l'auto-hébergement.
 
-## <a name="#decouvertegeneralepleroma">Découverte de l'interface de Pleroma</a>
+## Découverte de l'interface de Pleroma <a href="" name="decouvertegeneralepleroma"></a>
+
 Pour ceux et celles qui n'ont pas ou peu l'habitude des réseaux sociaux, voici en détail l'utilisation de chacune des fenêtres proposées.
 
 ### Accueil de l'interface
+
 <img src="/images/capture_globale.png" alt="Capture écran accueil de Pleroma">
 
 1. Barre de menu  
@@ -34,7 +36,7 @@ Cet espace permet de choisir l'agencement de Pleroma, il est proposé deux agenc
 6. Notifications  
 On retrouve dans cette zone les messages où vous avez été cité, mais aussi les abonnements à votre compte.
 
-## <a name="LogicielsClients"> Applications clients</a>
+## Applications clients <a href="" name="LogicielsClients"></a>
 
 | Nom de l'applications | Plateforme | Multi-comptes | Autre réseaux supportés | Play Store | F-Droid | Apple Store |
 |---|---|---|---|---|---|---|
@@ -43,7 +45,8 @@ On retrouve dans cette zone les messages où vous avez été cité, mais aussi l
 | Twidere | Android | Oui | Twitter, Mastodon | [play.google.com/org.mariotaku.twidere](https://play.google.com/store/apps/details?id=org.mariotaku.twidere) | [https://f-droid.org/org.mariotaku.twidere](https://f-droid.org/fr/packages/org.mariotaku.twidere/) | 
 | Librem Social | Android | Non | ? | [play.google.com/one.librem.social](https://play.google.com/store/apps/details?id=one.librem.social&hl=fr) | [https://f-droid.org/one.librem.social](https://f-droid.org/fr/packages/one.librem.social) | |
 
-## <a name="liensutiles">Quelques liens utiles</a>
+## Quelques liens utiles <a href="" name="liensutiles"></a>
+
 + Site officiel : [pleroma.social (En anglais)](https://pleroma.social)
 + Trouver d'autres instances de Pleroma : [fediverse.network/pleroma](https://fediverse.network/pleroma)
 + Trouver de l'aide et poser toutes vos questions : [forum.yunohost.org](https://forum.yunohost.org/c/support)

--- a/app_pleroma_fr.md
+++ b/app_pleroma_fr.md
@@ -49,4 +49,3 @@ On retrouve dans cette zone les messages où vous avez été cité, mais aussi l
 
 + Site officiel : [pleroma.social (En anglais)](https://pleroma.social)
 + Trouver d'autres instances de Pleroma : [fediverse.network/pleroma](https://fediverse.network/pleroma)
-+ Trouver de l'aide et poser toutes vos questions : [forum.yunohost.org](https://forum.yunohost.org/c/support)

--- a/app_sogo_fr.md
+++ b/app_sogo_fr.md
@@ -6,4 +6,3 @@ SOGo est un service de webmail pour votre serveur email, c'est une alternative Ã
 
  + Site officiel de SOGo : [sogo.nu](https://sogo.nu/a)
  + DÃ©pot de l'application pour Yunohost : [github.com/YunoHost-Apps/sogo_ynh](https://github.com/YunoHost-Apps/sogo_ynh)
- + Trouver de l'aide et poser vos questions sur le [forum de Yunohost](https://forum.yunohost.org/c/support/apps)

--- a/app_sogo_fr.md
+++ b/app_sogo_fr.md
@@ -1,9 +1,9 @@
 # ![Logo SOGo](/images/logo_sogo.png) SOGo
 
- - [Liens Utiles](#LiensUtiles)
 SOGo est un service de webmail pour votre serveur email, c'est une alternative à [RoundCube](app_roundcube). Il permet aussi la gestion des agendas et contacts présents sur le serveur.
 
-## <a name="LiensUtiles">Quelques liens utiles</a>
+## Quelques liens utiles
+
  + Site officiel de SOGo : [sogo.nu](https://sogo.nu/a)
  + Dépot de l'application pour Yunohost : [github.com/YunoHost-Apps/sogo_ynh](https://github.com/YunoHost-Apps/sogo_ynh)
  + Trouver de l'aide et poser vos questions sur le [forum de Yunohost](https://forum.yunohost.org/c/support/apps)


### PR DESCRIPTION
For instance, https://yunohost.org/#/app_nextcloud_fr is currently broken because of this ...

I guess this was tested in Github and works fine in Github, but Simone's markdown parser works differently and miserably crash because of a missing `href=""` in the anchor ...

Realized while doing this that some stuff were currently a bit overkill / not needed for now ...

Also this thing with link anchors is creating weird behavior because the HTML anchor is already used for the page name ... so e.g. when clicking on a link/anchor inside the app_nextcloud_fr page, the URL in the bar gets changed to `https://yunohost.org/#somelink` instead of something like `https://yunohost.org/#/app_nextcloud_fr#somelink` (but in fact you simply can't have multiple html anchor so ...)

So idk what's the right solution (beside moving to Grav lol idk)