### PR TITLE
[enh] add first version of news.md

### DIFF
--- a/news.md
+++ b/news.md
@@ -1,0 +1,49 @@
+# YunoHost News
+
+<div id="news">
+</div>
+
+<style>
+.emoji {
+    height: 21px;
+}
+
+blockquote p {
+    font-size: medium;
+}
+blockquote > p {
+    margin-top: 0;
+}
+</style>
+
+<script type="text/template" id="news-template">
+    <article class="news">
+        <h2><a target="_blank" href="{link}">{title}</a></h2>
+
+        <div>{body}</div>
+    </article>
+
+    <hr>
+</script>
+
+<script>
+$(document).ready(function() {
+    // FIXME, we need to enable CORS on forum.yunohost.org
+    // $.get("https://forum.yunohost.org/c/announcement.rss").success(function(data) {
+    $.get("/_pages/announcement.rss").success(function(data) {
+        $(data).find("item").each(function(_, item) {
+            var description = $(item).find("description");
+            // yes this is a NIGHTMARE
+            var blockquote_content = $("<div>" + description[0].textContent + "</div>").find("blockquote")[0].innerHTML
+            // blockquote_content = blockquote_content.replace("<h1", "<h4");
+
+            html = $('#news-template').html()
+             .replace(/{title}/g, $(item).find("title").text())
+             .replace(/{link}/g, $(item).find("link").text())
+             .replace(/{body}/g, blockquote_content)
+
+            $("#news").append(html);
+        })
+    })
+})
+</script>


### PR DESCRIPTION
Hello,

After a small discussion with @decentral1se he asked what needed to be done to integrate the news inside Simone. I'm quite out of loop so that might not be the thing you lastly discussed but I came with a prototype of what we've talked about in the past: this create a new page of the doc call "/news", it uses (well, should be, see bellow*) the RSS of the "annoucement" (for now) category using javascript and generate a page for that.

* for now CORS is not enabled on forum.yunohost.org so it doesn't work but the prototype works with the exact same file content

Here is the result for now:

![2019-11-03-134818_715x766_scrot](https://user-images.githubusercontent.com/41827/68085370-9b659a80-fe40-11e9-843c-96bf605b5e80.png)

It is not perfect as discourse is quite an idiot and do with stuff like replacing all `<img>` by `<a href="link to image">filename</a>` which can't be easily fixed. And some other weird stuff.

But at least this is a working prototype if we want to build on top of that (if it's the decided direction)