### PR TITLE
Burn or Copy ISO: Change dd instructions from /dev/sdb to /dev/sdz

### DIFF
--- a/burn_or_copy_iso.md
+++ b/burn_or_copy_iso.md
@@ -28,10 +28,10 @@ Put your USB stick on, select your YunoHost ISO and click "OK"
 ### With `dd`
 
 If you know your way around command line, you may also flash your USB stick with
-`dd`. Assuming your USB stick is `/dev/sdb` (be careful !!), you may run :
+`dd`. Assuming your USB stick is `/dev/sdz` (be careful !!), you may run :
 
 ```bash
-dd if=/path/to/yunohost.iso of=/dev/sdb
+dd if=/path/to/yunohost.iso of=/dev/sdz
 ```
 
 ---

--- a/burn_or_copy_iso_fr.md
+++ b/burn_or_copy_iso_fr.md
@@ -28,11 +28,11 @@ Branchez votre clef USB, selectionnez l'ISO YunoHost puis cliquez sur 'OK'
 ### Avec `dd`
 
 Si vous êtes familier avec la ligne de commande, il est possible de flasher la
-clef USB avec `dd`. En supposant que votre clef USB soit `/dev/sdb` (faites
+clef USB avec `dd`. En supposant que votre clef USB soit `/dev/sdz` (faites
 attention !!), vous pouvez exécuter :
 
 ```bash
-dd if=/chemin/de/yunohost.iso of=/dev/sdb
+dd if=/chemin/de/yunohost.iso of=/dev/sdz
 ```
 
 ---


### PR DESCRIPTION
It's better for dd to create a file called sdz than it is for it to overwrite someone's second disk (if they have ssd/hdd, that'd be their bulk storage).