### PR TITLE
Some improvements to  app_nextcloud_keeweb.md 

### DIFF
--- a/app_nextcloud_keeweb.md
+++ b/app_nextcloud_keeweb.md
@@ -1,4 +1,4 @@
-# The KeeWeb application
+# The KeeWeb application for NextCloud
 
 The KeeWeb application is a password manager integrated into Nextcloud. For example, it allows you to read a KeePass file (*.kdbx*) stored on your Nextcloud instance.
 But sometimes Nextcloud does not let the application support these files, which makes it impossible to read them from KeeWeb. To remedy this,

--- a/app_nextcloud_keeweb.md
+++ b/app_nextcloud_keeweb.md
@@ -2,7 +2,7 @@
 
 The KeeWeb application is a password manager integrated into Nextcloud. For example, it allows you to read a KeePass file (*.kdbx*) stored on your Nextcloud instance.
 But sometimes Nextcloud does not let the application support these files, which makes it impossible to read them from KeeWeb. To remedy this,
-[a solution](https://github.com/jhass/nextcloud-keeweb/issues/34) exists.
+[a solution](https://github.com/jhass/nextcloud-keeweb/blob/master/README.md#mimetype-detection) exists.
 
 Go to the Nextcloud configuration directory:
 
@@ -25,5 +25,11 @@ Then add in this file the following text:
 ```
 
 Save the file (**CTRL** + **o**) and exit nano (**CTRL** + **c**).
+
+Then run a scan by executing next command as root:
+
+```bash
+sudo -u nextcloud php /var/www/nextcloud/occ files:scan --all
+```
 
 Now the problem is fixed.

--- a/app_nextcloud_keeweb_fr.md
+++ b/app_nextcloud_keeweb_fr.md
@@ -29,4 +29,10 @@ Puis ajouter dans ce fichier le texte suivent :
 
 Enregistrer le fichier (**CTRL** + **o**) et quitter nano (**CTRL** + **c**).
 
+Ensuite lancer un scan en tant que root:
+
+```bash
+sudo -u nextcloud php /var/www/nextcloud/occ files:scan --all
+```
+
 A présent, le problème est corrigé.

--- a/app_nextcloud_keeweb_fr.md
+++ b/app_nextcloud_keeweb_fr.md
@@ -1,4 +1,4 @@
-# L'application KeeWeb
+# L'application KeeWeb pour NextCloud
 
 L'application Keeweb sur le catalogue de nextcloud - [apps.nextcloud.com/keeweb](https://apps.nextcloud.com/apps/keeweb)
 


### PR DESCRIPTION
After participating to  https://forum.yunohost.org/t/installation-keeweb/9851/1 (I'm Lops on the forum), I wanted to add some information to app_nextcloud_keeweb(_fr).md, especially to avoid confusion between

* [Nextcloud KeeWeb app](https://apps.nextcloud.com/apps/keeweb)
* [Yunohost KeeWeb app](https://github.com/YunoHost-Apps/keeweb_ynh)