### PR TITLE
[rem] ZeroTier from apps wishlist

### DIFF
--- a/apps_wishlist.md
+++ b/apps_wishlist.md
@@ -159,7 +159,6 @@ The following list is a compiled wishlist of applications that would be nice-to-
 - [Xibo](https://github.com/xibosignage) - A FLOSS digital signage solution (CMS?)
 - [Xonotic](http://xonotic.org) / [gitlab](https://gitlab.com/xonotic)
 - [Zammad](https://github.com/zammad/zammad)
-- [ZeroTier](https://github.com/zerotier/ZeroTierOne)
 - [Zola](https://www.getzola.org/) - A static site generator in one binary
 - [Zoneminder](https://github.com/ZoneMinder/zoneminder)
 - [Zulip](https://zulipchat.com/) / [github](https://github.com/zulip/zulip)


### PR DESCRIPTION
ZeroTier was implemented (https://github.com/tituspijean/zerotier_ynh), but not listed, as a non-free app.