### PR TITLE
Update to Swisscom policy

### DIFF
--- a/isp.md
+++ b/isp.md
@@ -55,7 +55,7 @@ Most of non business IP provided by ISP are blacklisted.
 | Service provider | Box (modem/router) | uPnP available | Port 25 openable | [Hairpinning](http://en.wikipedia.org/wiki/Hairpinning) | Customizable reverse DNS | Fix IP |
 | --- | --- | --- | --- | --- | --- | --- |
 | Sunrise | Multiple | No | Yes | No | - | - |
-| Swisscom | Multiple | No | Yes | No | - | - |
+| Swisscom | Multiple | No | Yes | No | No | No |
 | VTX | Multiple | No | Yes | No | - | - |
 
 If you want to add international ISPs information, please do consider [modifying this page](/write_documentation).


### PR DESCRIPTION
I contacted Swisscom and they told me they do not provide fix IP addresses to private customers (as it is not compatible with SwisscomTV). They do not provide customizable reverse DNS service for private customers neither.