### PR TITLE
Add Dendrite to wishlist

### DIFF
--- a/apps_wishlist.md
+++ b/apps_wishlist.md
@@ -41,6 +41,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [Cozy](https://cozy.io/en/) |  |  |  |
 | Croodle | Vote for a schedule / polling | [Upstream](https://github.com/jelhan/croodle) |  |
 | [Darkwire.io](https://darkwire.io/) | End-to-end encrypted instant web chat | [Upstream](https://github.com/seripap/darkwire.io) |  |
+| Dendrite | Next-gen Matrix server in Go | [Upstream](https://github.com/matrix-org/dendrite) | |
 | [democracyOS](https://democracyos.org/) | Vote / make decisions in a collective |  | [Package Draft](https://github.com/YunoHost-Apps/democracyos_ynh) |
 | [diasporadocker](https://diasporafoundation.org/) | A open and powerfull social network |  | [Package Draft](https://github.com/aymhce/diasporadocker_ynh) |
 | DirectoryLister |  | [Upstream](https://github.com/DirectoryLister/DirectoryLister) |  |


### PR DESCRIPTION
A more efficient Matrix server, supposedly the successor of Synapse :stuck_out_tongue_winking_eye: 

N.B. : still currently in Beta ! https://matrix.org/blog/2020/10/08/dendrite-is-entering-beta

In particular : 

>Dendrite is ready for early adopters. We recommend running in Monolith mode with a PostgreSQL database.
[...]
>For small homeserver installations joined on ~10s rooms on matrix.org with ~100s of users in those rooms, including some encrypted rooms:
>   Memory: uses around 100MB of RAM, with peaks at around 200MB.
>   Disk space: After a few months of usage, the database grew to around 2GB (in Monolith mode).
>    CPU: Brief spikes when processing events, typically idles at 1% CPU.
>This means Dendrite should comfortably work on things like Raspberry Pis.
