### PR TITLE
Add Galène to wishlist

### DIFF
--- a/apps_wishlist.md
+++ b/apps_wishlist.md
@@ -76,6 +76,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [freepbx](https://freepbx.org) | VOIP |  | [Package Draft](https://github.com/YunoHost-Apps/freepbx_ynh) |
 | [ftssolr](https://wiki.dovecot.org/Plugins/FTS/Solr) | Full-text search via IMAP through a Solr indexing server |  | [Package Draft](https://github.com/YunoHost-Apps/ftssolr_ynh) |
 | galette | Membership management for non-profit organizations |  | [Package Draft](https://github.com/YunoHost-Apps/galette_ynh) |
+| [Galène](https://galene.org/) | videoconferencing server | [Upstream](https://github.com/jech/galene) |  |
 | [Gancio](https://gancio.org/) |  | [Upstream](https://framagit.org/les/gancio) |  |
 | gateone | HTML5-powered terminal emulator and SSH client |  | [Package Draft](https://github.com/Kloadut/gateone_ynh) |
 | [Geneweb](https://geneweb.tuxfamily.org) |  | [Upstream](https://github.com/geneweb/geneweb) |  |


### PR DESCRIPTION
Add [Galène](https://galene.org/) to wishlist.
https://linuxfr.org/news/galene-un-serveur-de-videoconference-libre