### PR TITLE
Add shebang to dead_links. Proper loop on command stdout.

### DIFF
--- a/tests/dead_links.sh
+++ b/tests/dead_links.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
 returncode=0
 
 # Parse default routes
@@ -7,11 +10,10 @@ grep -roh "^ *default: .*" ./pages | awk '{print $2}' | tr -d "'" | sort | uniq 
 grep -rh "^---$" ./pages -B 50 | grep "^   *\- '/" | awk '{print $2}' | tr -d "'" | sort | uniq >> .known_pages
 
 # Find all markdown links and generate a list of filename.md:N:linktarget   (with N the line number)
-for LINK in $(grep -nr -o -E "\]\(\/?(\w|-)+\)" ./pages)
-do
-    PAGE=$(echo $LINK | awk -F: '{print $3}' | tr -d ']()/')
 
-    grep -qw "$PAGE" ./.known_pages || { echo $LINK; returncode=1; }
-done
+while IFS= read -r LINK; do
+    PAGE=$(echo "$LINK" | awk -F: '{print $3}' | tr -d ']()/')
+    grep -qw "$PAGE" ./.known_pages || { echo "$LINK"; returncode=1; }
+done < <(grep -nr -o -E "\]\(\/?(\w|-)+\)" ./pages)
 
 exit $returncode


### PR DESCRIPTION
I wanted to use the dead_links script but it was not executable and was missing a shebang. 

I also added bash set "fail on error" flags, and rewrote the loop.