### PR TITLE
Add Lingva Translate

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -133,6 +133,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [LBCAlerte](https://alerte.ilatumi.org/) |  |  | [Package Draft](https://github.com/YunoHost-Apps/LBCAlerte_ynh) |
 | lektor | A static website generator |  | [Package Draft](https://github.com/YunoHost-Apps/lektor_ynh) |
 | [Lessy](https://lessy.io) |  | [Upstream](https://github.com/lessy-community/lessy) |  |
+| [Lingva Translate](https://lingva.ml/) | Alternative front-end for Google Translate | [Upstream](https://github.com/TheDavidDelta/lingva-translate) |  |
 | linuxdash | Low-overhead monitoring web dashboard | [Upstream](https://github.com/afaqurk/linux-dash) | [Package Draft](https://github.com/YunoHost-Apps/linuxdash_ynh) |
 | [LiquidSoap](https://www.liquidsoap.info/) | Audio and video streaming language | [Upstream](https://github.com/savonet/liquidsoap) |  |
 | [listmonk](https://listmonk.app) | Self-hosted newsletter & mailing list manager | [Upstream](https://github.com/knadh/listmonk) | |


### PR DESCRIPTION
[Lingva Translate](https://lingva.ml/) is an alternative front-end for Google Translate with the [Upstream](https://github.com/TheDavidDelta/lingva-translate)