### PR TITLE
Add LibreTranslate

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -133,6 +133,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [LBCAlerte](https://alerte.ilatumi.org/) |  |  | [Package Draft](https://github.com/YunoHost-Apps/LBCAlerte_ynh) |
 | lektor | A static website generator |  | [Package Draft](https://github.com/YunoHost-Apps/lektor_ynh) |
 | [Lessy](https://lessy.io) |  | [Upstream](https://github.com/lessy-community/lessy) |  |
+| [LibreTranslate](https://libretranslate.com/) | Free and Open Source Machine Translation API: 100% self-hosted, no limits, no ties to proprietary services, built on top of Argos Translate | [Upstream](https://github.com/uav4geo/LibreTranslate) |  |
 | linuxdash | Low-overhead monitoring web dashboard | [Upstream](https://github.com/afaqurk/linux-dash) | [Package Draft](https://github.com/YunoHost-Apps/linuxdash_ynh) |
 | [LiquidSoap](https://www.liquidsoap.info/) | Audio and video streaming language | [Upstream](https://github.com/savonet/liquidsoap) |  |
 | [listmonk](https://listmonk.app) | Self-hosted newsletter & mailing list manager | [Upstream](https://github.com/knadh/listmonk) | |


### PR DESCRIPTION
[LibreTranslate](https://libretranslate.com/) is a free and Open Source Machine Translation API: 100% self-hosted, no limits, no ties to proprietary services, built on top of Argos Translate with the [Upstream](https://github.com/uav4geo/LibreTranslate)