### PR TITLE
Add qBit MatUI for qBittorrent

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -218,7 +218,8 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | pydio | File sharing platform |  | [Package Draft](https://github.com/YunoHost-Apps/pydio_ynh) |
 | [Pydio Cells](https://pydio.com/) |  | [Upstream](https://github.com/pydio/cells) |  |
 | [pyload](https://pyload.net/) |  | [Upstream](https://github.com/pyload/pyload) | [Package Draft](https://github.com/YunoHost-Apps/pyload_ynh) |
-| qBittorrent |  | [Upstream](https://github.com/qbittorrent/qBittorrent) |  |
+| [qBit MatUI](https://qbit-material-webui-demo.herokuapp.com/) | A material WebUI for qBittorrent, written in Angular | [Upstream](https://github.com/bill-ahmed/qbit-matUI) |  |
+| [qBittorrent](https://www.qbittorrent.org/) |  | [Upstream](https://github.com/qbittorrent/qBittorrent) |  |
 | [Questions2answer](https://www.question2answer.org/) |  |  |  |
 | [racktables](https://racktables.org) |  | [Upstream](https://github.com/RackTables/racktables) |  |
 | Radarr |  | [Upstream](https://github.com/Radarr/Radarr) |  |

--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -218,7 +218,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | pydio | File sharing platform |  | [Package Draft](https://github.com/YunoHost-Apps/pydio_ynh) |
 | [Pydio Cells](https://pydio.com/) |  | [Upstream](https://github.com/pydio/cells) |  |
 | [pyload](https://pyload.net/) |  | [Upstream](https://github.com/pyload/pyload) | [Package Draft](https://github.com/YunoHost-Apps/pyload_ynh) |
-| [qBit MatUI](https://qbit-material-webui-demo.herokuapp.com/) | A material WebUI for qBittorrent, written in Angular | [Upstream](https://github.com/bill-ahmed/qbit-matUI) |  |
+| [qBit MatUI](https://qbit-material-webui-demo.herokuapp.com/) | A WebUI for qBittorrent | [Upstream](https://github.com/bill-ahmed/qbit-matUI) |  |
 | [qBittorrent](https://www.qbittorrent.org/) |  | [Upstream](https://github.com/qbittorrent/qBittorrent) |  |
 | [Questions2answer](https://www.question2answer.org/) |  |  |  |
 | [racktables](https://racktables.org) |  | [Upstream](https://github.com/RackTables/racktables) |  |


### PR DESCRIPTION
[qBit MatUI](https://qbit-material-webui-demo.herokuapp.com/) is a material WebUI for qBittorrent, written in Angular, with the [Upstream](https://github.com/bill-ahmed/qbit-matUI)