### PR TITLE
Add Baserow

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -27,6 +27,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [AnonAddy](https://anonaddy.com/) | Anonymous email forwarding - Create Unlimited Email Aliases For Free | [Upstream](https://github.com/anonaddy/anonaddy) |  |
 | [ArchiveBox](https://archivebox.io/) | Open source self-hosted web archiving |[Upstream](https://github.com/ArchiveBox/ArchiveBox)|  |
 | [askbot](https://askbot.com/) | Questions and answers |  | [Package Draft](https://github.com/zamentur/askbot_ynh) |
+| [Baserow](https://baserow.io/) | Open source no-code database tool and Airtable alternative. | [Upstream](https://gitlab.com/bramw/baserow) |  |
 | [BicBucStriim](https://projekte.textmulch.de/bicbucstriim/) | Manage an e-book collection |  | [Package Draft](https://github.com/YunoHost-Apps/bicbucstriim_ynh) |
 | [BigBlueButton](https://bigbluebutton.org) | Web conferencing system | [Upstream](https://github.com/bigbluebutton/bigbluebutton) |  |
 | [Bitmessage](https://bitmessage.org/) |  | [Upstream](https://github.com/Bitmessage/PyBitmessage) |  |


### PR DESCRIPTION
Hi,
I really like flexible custom database tools like Airtable, and haven't found a equivalent in the Yunohost apps catalog (but maybe I'm wrong !).  I think this kid of tools are great for small organizations as they help create data structures and visualizations easily, without using a database yourself or heavy ERP app.
Baserow is an Airtable alternative, it has been released a few months ago and I've been following the app's progress. So far it works nicely and is regularly updated. It's mainly Open Source, although some features are reserved for Premium users. 
I am not a developer so I do not know how I can help, if I can let me know ! Just putting this on the wishlist in case other people are interested...

Thanks to all the yunohost devs and community for all the great work 🙂 