### PR TITLE
Fix CHATON url

### DIFF
--- a/pages/03.community/11.chatons/chatons.fr.md
+++ b/pages/03.community/11.chatons/chatons.fr.md
@@ -1,5 +1,5 @@
 ---
 title: Créer son CHATONS avec YunoHost
 template: docs
-redirect: 'https://wiki.chatons.org/doku.php/yunohost'
+redirect: 'https://wiki.chatons.org/doku.php/heberger/administration_systeme/yunohost'
 ---

--- a/pages/03.community/11.chatons/chatons.md
+++ b/pages/03.community/11.chatons/chatons.md
@@ -1,5 +1,5 @@
 ---
 title: Creating a CHATONS with YunoHost
 template: docs
-redirect: 'https://wiki.chatons.org/doku.php/yunohost'
+redirect: 'https://wiki.chatons.org/doku.php/heberger/administration_systeme/yunohost'
 ---


### PR DESCRIPTION
The yunohost page changed on wiki.chatons.org.