### PR TITLE
Adding references to the english/french versions of the ISP list

### DIFF
--- a/pages/01.administrate/07.specific_use_cases/02.isp/isp.es.md
+++ b/pages/01.administrate/07.specific_use_cases/02.isp/isp.es.md
@@ -11,6 +11,8 @@ routes:
 
 Aquí tienes una lista (no exhaustiva) de proveedores de acceso a Internet por país, con criterios de compatibilidad con el [self-hosting](/selfhosting).
 
+!!!! Una lista más completa de proveedores de acceso a Internet es disponible por [la versión en inglés de esta página](../en/isp).
+
 Un « **no** » puede implicar problemas de utilización del servidor o puede obligarte a hacer configuraciones adicionales. El estatus entre paréntesis indica el comportamiento por defecto.
 
 ### Francia

--- a/pages/01.administrate/07.specific_use_cases/02.isp/isp.fr.md
+++ b/pages/01.administrate/07.specific_use_cases/02.isp/isp.fr.md
@@ -9,7 +9,9 @@ routes:
 
 [div class="btn btn-lg btn-default"] [ Configuration générale box](/isp_box_config) [/div]
 
-Voici une liste non exhaustive des fournisseurs d’accès à Internet par pays, contenant les critères de tolérance à l’[auto-hébergement](/selfhosting).
+Voici une liste non exhaustive des fournisseurs d’accès à Internet pour quelques pays francophones, contenant les critères de tolérance à l’[auto-hébergement](/selfhosting).
+
+!!!! Pour une liste internationale un peu plus complète, référez-vous à [la version anglaise de cette page](/../en/isp).
 
 Un « **non** » peut entraîner des problèmes d’utilisation de votre serveur ou peut vous obliger à faire des configurations supplémentaires. Le statut entre parenthèses indique le comportement par défaut.
 

--- a/pages/01.administrate/07.specific_use_cases/02.isp/isp.md
+++ b/pages/01.administrate/07.specific_use_cases/02.isp/isp.md
@@ -11,9 +11,9 @@ routes:
 
 Here is a non-comprehensive list of internet service providers by country, which contains criteria about tolerance to self-hosting.
 
-A "no" may cause problems for using your server or may require you to make additional configuration changes. Status in brackets indicates the default behavior.
+!!!! For a list of French-speaking countries ISP, check [the french version of this page](../fr/isp).
 
-(For the list of ISP in France/Belgian, check the french version of this page)
+A "no" may cause problems for using your server or may require you to make additional configuration changes. Status in brackets indicates the default behavior.
 
 ### USA
 | Service provider | Box (modem/router) | uPnP available | Port 25 openable | [Hairpinning](http://en.wikipedia.org/wiki/Hairpinning) | Customizable reverse DNS | Fix IP |


### PR DESCRIPTION
The English ISP list is the most internationally complete, the French one only has French-speaking countries... let's at least point that out for our readers. :)