### PR TITLE
yunohost ne permet plus d’autoriser ssh. Ah ben si !

### DIFF
--- a/pages/01.administrate/06.overview/04.commandline/ssh.de.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.de.md
@@ -80,13 +80,13 @@ By default, only the `admin` user can log in to YunoHost SSH server.
 YunoHost's users created via the administration interface are managed by the LDAP directory. By default, they can't connect via SSH for security reasons. If you want some users to have SSH access enabled, use the command:
 
 ```bash
-yunohost user ssh allow <username>
+yunohost user permission add ssh.main <username>
 ```
 
 It is also possible to remove SSH access using the following:
 
 ```bash
-yunohost user ssh disallow <username>
+yunohost user permission remove ssh.main <username>
 ```
 
 Finally, it is possible to add, delete and list SSH keys, to improve SSH access security, using the commands:

--- a/pages/01.administrate/06.overview/04.commandline/ssh.de.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.de.md
@@ -104,7 +104,7 @@ N.B. : `fail2ban` will ban your IP for 10 mimutes if you perform 5 failed login 
 A more extensive discussion about security & SSH can be found on the [dedicated page](/security).
 
 
-## Yunohost command line
+## YunoHost command line
 
 !!! Providing a full tutorial about the command line is quite beyond the scope of the YunoHost documentation : for this, consider reading a dedicated tutorial such as [this one](https://ryanstutorials.net/linuxtutorial/) or [this one](http://linuxcommand.org/). But be reassured that you don't need to be a CLI expert to start using it !
 

--- a/pages/01.administrate/06.overview/04.commandline/ssh.es.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.es.md
@@ -84,7 +84,6 @@ yunohost user permission add ssh.main <username>
 Del mismo modo, es posible cancelar el acceso SSH de un usuario con el comando :
 ```bash
 yunohost user permission remove ssh.main <username>
-
 ```
 
 Finalmente, es posible añadir, suprimir y listar llaves SSH, para mejorar la seguridad del acceso SSH, con estos comandos :

--- a/pages/01.administrate/06.overview/04.commandline/ssh.es.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.es.md
@@ -78,12 +78,13 @@ Por defecto, sólo el usuario `admin` puede conectarse en SSH en una instancia Y
 
 Los usuarios YunoHost creados vea la interfaz de administración están administrados por la base de datos LDAP. Por defecto, no pueden conectarse en SSH por razones de seguridad. Si necesitas absolutamente que uno de estos usuarios disponga de un acceso SSH, puedes utilizar el comando :
 ```bash
-yunohost user ssh allow <username>
+yunohost user permission add ssh.main <username>
 ```
 
 Del mismo modo, es posible cancelar el acceso SSH de un usuario con el comando :
 ```bash
-yunohost user ssh disallow <username>
+yunohost user permission remove ssh.main <username>
+
 ```
 
 Finalmente, es posible añadir, suprimir y listar llaves SSH, para mejorar la seguridad del acceso SSH, con estos comandos :

--- a/pages/01.administrate/06.overview/04.commandline/ssh.fr.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.fr.md
@@ -13,20 +13,20 @@ page-toc:
 
 ## Qu’est-ce que SSH ?
 
-**SSH** est un acronyme pour Secure Shell, et désigne un protocole qui permet de contrôler et administrer à distance une machine via la ligne de commande (CLI). C'est aussi une commande disponible de base dans les terminaux de GNU/Linux et macOS. Sous Windows, il vous faudra utiliser le logiciel [MobaXterm](https://mobaxterm.mobatek.net/download-home-edition.html) (après l'avoir lancé, cliquer sur Session puis SSH).
+**SSH** est un acronyme pour Secure Shell, et désigne un protocole qui permet de contrôler et administrer à distance une machine via la ligne de commande (CLI). C’est aussi une commande disponible de base dans les terminaux de GNU/Linux et macOS. Sous Windows, il vous faudra utiliser le logiciel [MobaXterm](https://mobaxterm.mobatek.net/download-home-edition.html) (après l’avoir lancé, cliquer sur Session puis SSH).
 
-L'interface en ligne de commande (CLI) est, en informatique, la manière originale (et plus technique) d'interagir avec un ordinateur comparé aux interfaces graphiques. La ligne de commande est généralement considérée comme plus complète, puissante et efficace que les interfaces graphiques, bien que plus difficile à apprendre.
+L’interface en ligne de commande (CLI) est, en informatique, la manière originale (et plus technique) d’interagir avec un ordinateur comparé aux interfaces graphiques. La ligne de commande est généralement considérée comme plus complète, puissante et efficace que les interfaces graphiques, bien que plus difficile à apprendre.
 
 ## Quelle adresse utiliser pour se connecter au serveur ?
 
 Si vous hébergez votre serveur **à la maison** (par ex. Raspberry Pi ou OLinuXino ou vieil ordinateur)
    - vous devriez pouvoir vous connecter à la machine en utilisant `yunohost.local`. 
-   - si `yunohost.local` ne fonctionne pas, il vous faut [trouver l'IP locale de votre serveur](/finding_the_local_ip).
-   - si vous avez installé votre serveur à la maison mais essayez d'y accéder depuis l'extérieur du réseau local, assurez-vous d'avoir bien configuré une redirection de port pour le port 22
+   - si `yunohost.local` ne fonctionne pas, il vous faut [trouver l’IP locale de votre serveur](/finding_the_local_ip).
+   - si vous avez installé votre serveur à la maison mais essayez d’y accéder depuis l’extérieur du réseau local, assurez-vous d’avoir bien configuré une redirection de port pour le port 22
 
-S'il s'agit d'une machine distante (VPS), votre fournisseur devrait vous avoir communiqué l'IP de votre machine.
+S’il s’agit d’une machine distante (VPS), votre fournisseur devrait vous avoir communiqué l’IP de votre machine.
 
-Dans tous les cas, si vous avez déjà configuré un nom de domaine qui pointe sur l'IP appropriée, il est plus pratique d'utiliser `votre.domaine.tld` plutôt que l'adresse IP.
+Dans tous les cas, si vous avez déjà configuré un nom de domaine qui pointe sur l’IP appropriée, il est plus pratique d’utiliser `votre.domaine.tld` plutôt que l’adresse IP.
 
 ## Identifiants pour se connecter
 
@@ -37,7 +37,7 @@ Dans tous les cas, si vous avez déjà configuré un nom de domaine qui pointe s
 
 ### APRÈS la post-installation
 
-Durant la postinstallation, vous avez défini un mot de passe d'administration. C'est ce mot de passe qui devient le nouveau mot de passe pour les utilisateurs `root` et `admin`. De plus, **la connexion en SSH avec l'utilisateur `root` est désactivée et il vous faut utiliser l'utilisateur `admin` !**. L'exception à cette règle est qu'il reste possible de se logger en root *depuis le réseau local - ou depuis une console en direct sur la machine* (ce qui peut être utile dans l'éventualité ou le serveur LDAP est inactif et l'utilisateur admin ne fonctionne plus).
+Durant la postinstallation, vous avez défini un mot de passe d’administration. C’est ce mot de passe qui devient le nouveau mot de passe pour les utilisateurs `root` et `admin`. De plus, **la connexion en SSH avec l’utilisateur `root` est désactivée et il vous faut utiliser l’utilisateur `admin` !**. L’exception à cette règle est qu’il reste possible de se logger en root *depuis le réseau local - ou depuis une console en direct sur la machine* (ce qui peut être utile dans l’éventualité ou le serveur LDAP est inactif et l’utilisateur admin ne fonctionne plus).
 
 ## Se connecter
 
@@ -51,7 +51,7 @@ ssh root@11.22.33.44
 ssh admin@11.22.33.44
 ```
 
-Ou bien en utilisant le nom de domaine plutôt que l'IP (plus pratique) :
+Ou bien en utilisant le nom de domaine plutôt que l’IP (plus pratique) :
 
 ```bash
 ssh admin@votre.domaine.tld
@@ -59,29 +59,22 @@ ssh admin@votre.domaine.tld
 ssh admin@yunohost.local
 ```
 
-Si vous avez changé le port SSH, il faut rajouter l'option `-p <numerodeport>` à la commande, par ex. :
+Si vous avez changé le port SSH, il faut rajouter l’option `-p <numerodeport>` à la commande, par ex. :
 
 ```bash
 ssh -p 2244 admin@votre.domaine.tld
 ```
 
-!!! Si vous êtes connecté en tant qu'`admin` et souhaitez devenir `root` pour plus de confort (par exemple, ne pas avoir à taper `sudo` à chaque commande), vous pouvez devenir `root` en tapant `sudo su` ou `sudo -i`.
+!!! Si vous êtes connecté en tant qu’`admin` et souhaitez devenir `root` pour plus de confort (par exemple, ne pas avoir à taper `sudo` à chaque commande), vous pouvez devenir `root` en tapant `sudo su` ou `sudo -i`.
 
 ## Quels utilisateurs ?
 
-Par défaut, seulement l'utilisateur `admin` peut se logger en SSH sur une instance YunoHost.
+Par défaut, seul l’utilisateur `admin` peut se logger en SSH sur une instance YunoHost.
 
-Les utilisateurs YunoHost créés via l'interface d'administration sont gérés par la base de donnée LDAP. Par défaut, ils ne peuvent pas se connecter en SSH pour des raisons de sécurité. Si vous avez absolument besoin qu'un utilisateur dispose d'un accès SSH, vous pouvez utiliser la commande :
-```bash
-yunohost user ssh allow <username>
-```
+Les utilisateurs YunoHost créés via l’interface d’administration sont gérés par la base de donnée LDAP. Par défaut, ils ne peuvent pas se connecter en SSH pour des raisons de sécurité. Si vous avez absolument besoin qu’un utilisateur dispose d’un accès SSH, vous pouvez leur octroyer ce droit depuis l’interface d’administration~: dans le panneau de gestion des utilisateurs, il y a un bouton `Gérer les groupes et les autorisations`. Pour qu’un utilisateur ai le droit de se connecter en SSH, il suffit de lui ajouter la permission `SSH`.
 
-De même, il est possible de supprimer l'accès SSH à un utilisateur avec la commande :
-```bash
-yunohost user ssh disallow <username>
-```
 
-Enfin, il est possible d'ajouter, de supprimer et de lister des clés SSH, pour améliorer la sécurité de l'accès SSH, avec les commandes :
+Enfin, il est possible d’ajouter, de supprimer et de lister des clés SSH, pour améliorer la sécurité de l’accès SSH, avec les commandes :
 ```bash
 yunohost user ssh add-key <username> <key>
 yunohost user ssh remove-key <username> <key>
@@ -96,9 +89,9 @@ Une discussion plus complète de la sécurité et de SSH peut être trouvée sur
 
 ## La ligne de commande Yunohost
 
-!!! Fournir un tutoriel complet sur la ligne de commande est bien au-delà du cadre de la documentation de YunoHost : pour cela, référez-vous à des tutoriels comme [celui-ci](https://doc.ubuntu-fr.org/tutoriel/console_ligne_de_commande) ou [celui-ci (en)](http://linuxcommand.org/). Mais soyez rassuré qu'il n'y a pas besoin d'être un expert pour commencer à l'utiliser !
+!!! Fournir un tutoriel complet sur la ligne de commande est bien au-delà du cadre de la documentation de YunoHost : pour cela, référez-vous à des tutoriels comme [celui-ci](https://doc.ubuntu-fr.org/tutoriel/console_ligne_de_commande) ou [celui-ci (en)](http://linuxcommand.org/). Mais soyez rassuré qu’il n’y a pas besoin d’être un expert pour commencer à l’utiliser !
 
-La commande `yunohost` peut être utilisée pour administrer votre serveur ou réaliser les mêmes actions que celles disponibles sur la webadmin. Elle doit être lancée en depuis l'utilisateur `root`, ou bien depuis l'utilisateur `admin` en précédant la commande de `sudo`. (ProTip™ : il est possible de devenir `root` via la commande `sudo su` en tant qu'`admin`.)
+La commande `yunohost` peut être utilisée pour administrer votre serveur ou réaliser les mêmes actions que celles disponibles sur la webadmin. Elle doit être lancée en depuis l’utilisateur `root`, ou bien depuis l’utilisateur `admin` en précédant la commande de `sudo`. (ProTip™ : il est possible de devenir `root` via la commande `sudo su` en tant qu’`admin`.)
 
 Les commandes YunoHost ont ce type de structure :
 
@@ -109,7 +102,7 @@ yunohost app install wordpress --label Webmail
    categorie  action  argument     options
 ```
 
-N'hésitez pas à naviguer et demander des informations à propos d'une catégorie ou action donnée via l'option `--help`. Par exemple, ces commandes :
+N’hésitez pas à naviguer et demander des informations à propos d’une catégorie ou action donnée via l’option `--help`. Par exemple, ces commandes :
 
 ```bash
 yunohost --help
@@ -117,4 +110,4 @@ yunohost user --help
 yunohost user create --help
 ```
 
-vont successivement lister toutes les catégories disponibles, puis les actions de la catégorie `user`, puis expliquer comment utiliser l'action `user create`. Vous devriez remarquer que l'arbre des commandes YunoHost suit une structure similaire aux pages de la webadmin.
+vont successivement lister toutes les catégories disponibles, puis les actions de la catégorie `user`, puis expliquer comment utiliser l’action `user create`. Vous devriez remarquer que l’arbre des commandes YunoHost suit une structure similaire aux pages de la webadmin.

--- a/pages/01.administrate/06.overview/04.commandline/ssh.fr.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.fr.md
@@ -13,20 +13,20 @@ page-toc:
 
 ## Qu’est-ce que SSH ?
 
-**SSH** est un acronyme pour Secure Shell, et désigne un protocole qui permet de contrôler et administrer à distance une machine via la ligne de commande (CLI). C’est aussi une commande disponible de base dans les terminaux de GNU/Linux et macOS. Sous Windows, il vous faudra utiliser le logiciel [MobaXterm](https://mobaxterm.mobatek.net/download-home-edition.html) (après l’avoir lancé, cliquer sur Session puis SSH).
+**SSH** est un acronyme pour Secure Shell, et désigne un protocole qui permet de contrôler et administrer à distance une machine via la ligne de commande (CLI). C'est aussi une commande disponible de base dans les terminaux de GNU/Linux et macOS. Sous Windows, il vous faudra utiliser le logiciel [MobaXterm](https://mobaxterm.mobatek.net/download-home-edition.html) (après l'avoir lancé, cliquer sur Session puis SSH).
 
-L’interface en ligne de commande (CLI) est, en informatique, la manière originale (et plus technique) d’interagir avec un ordinateur comparé aux interfaces graphiques. La ligne de commande est généralement considérée comme plus complète, puissante et efficace que les interfaces graphiques, bien que plus difficile à apprendre.
+L'interface en ligne de commande (CLI) est, en informatique, la manière originale (et plus technique) d'interagir avec un ordinateur comparé aux interfaces graphiques. La ligne de commande est généralement considérée comme plus complète, puissante et efficace que les interfaces graphiques, bien que plus difficile à apprendre.
 
 ## Quelle adresse utiliser pour se connecter au serveur ?
 
 Si vous hébergez votre serveur **à la maison** (par ex. Raspberry Pi ou OLinuXino ou vieil ordinateur)
    - vous devriez pouvoir vous connecter à la machine en utilisant `yunohost.local`. 
-   - si `yunohost.local` ne fonctionne pas, il vous faut [trouver l’IP locale de votre serveur](/finding_the_local_ip).
-   - si vous avez installé votre serveur à la maison mais essayez d’y accéder depuis l’extérieur du réseau local, assurez-vous d’avoir bien configuré une redirection de port pour le port 22
+   - si `yunohost.local` ne fonctionne pas, il vous faut [trouver l'IP locale de votre serveur](/finding_the_local_ip).
+   - si vous avez installé votre serveur à la maison mais essayez d'y accéder depuis l'extérieur du réseau local, assurez-vous d'avoir bien configuré une redirection de port pour le port 22
 
-S’il s’agit d’une machine distante (VPS), votre fournisseur devrait vous avoir communiqué l’IP de votre machine.
+S'il s'agit d'une machine distante (VPS), votre fournisseur devrait vous avoir communiqué l'IP de votre machine.
 
-Dans tous les cas, si vous avez déjà configuré un nom de domaine qui pointe sur l’IP appropriée, il est plus pratique d’utiliser `votre.domaine.tld` plutôt que l’adresse IP.
+Dans tous les cas, si vous avez déjà configuré un nom de domaine qui pointe sur l'IP appropriée, il est plus pratique d'utiliser `votre.domaine.tld` plutôt que l'adresse IP.
 
 ## Identifiants pour se connecter
 
@@ -37,7 +37,7 @@ Dans tous les cas, si vous avez déjà configuré un nom de domaine qui pointe s
 
 ### APRÈS la post-installation
 
-Durant la postinstallation, vous avez défini un mot de passe d’administration. C’est ce mot de passe qui devient le nouveau mot de passe pour les utilisateurs `root` et `admin`. De plus, **la connexion en SSH avec l’utilisateur `root` est désactivée et il vous faut utiliser l’utilisateur `admin` !**. L’exception à cette règle est qu’il reste possible de se logger en root *depuis le réseau local - ou depuis une console en direct sur la machine* (ce qui peut être utile dans l’éventualité ou le serveur LDAP est inactif et l’utilisateur admin ne fonctionne plus).
+Durant la postinstallation, vous avez défini un mot de passe d'administration. C'est ce mot de passe qui devient le nouveau mot de passe pour les utilisateurs `root` et `admin`. De plus, **la connexion en SSH avec l'utilisateur `root` est désactivée et il vous faut utiliser l'utilisateur `admin` !**. L'exception à cette règle est qu'il reste possible de se logger en root *depuis le réseau local - ou depuis une console en direct sur la machine* (ce qui peut être utile dans l'éventualité ou le serveur LDAP est inactif et l'utilisateur admin ne fonctionne plus).
 
 ## Se connecter
 
@@ -51,7 +51,7 @@ ssh root@11.22.33.44
 ssh admin@11.22.33.44
 ```
 
-Ou bien en utilisant le nom de domaine plutôt que l’IP (plus pratique) :
+Ou bien en utilisant le nom de domaine plutôt que l'IP (plus pratique) :
 
 ```bash
 ssh admin@votre.domaine.tld
@@ -59,22 +59,29 @@ ssh admin@votre.domaine.tld
 ssh admin@yunohost.local
 ```
 
-Si vous avez changé le port SSH, il faut rajouter l’option `-p <numerodeport>` à la commande, par ex. :
+Si vous avez changé le port SSH, il faut rajouter l'option `-p <numerodeport>` à la commande, par ex. :
 
 ```bash
 ssh -p 2244 admin@votre.domaine.tld
 ```
 
-!!! Si vous êtes connecté en tant qu’`admin` et souhaitez devenir `root` pour plus de confort (par exemple, ne pas avoir à taper `sudo` à chaque commande), vous pouvez devenir `root` en tapant `sudo su` ou `sudo -i`.
+!!! Si vous êtes connecté en tant qu'`admin` et souhaitez devenir `root` pour plus de confort (par exemple, ne pas avoir à taper `sudo` à chaque commande), vous pouvez devenir `root` en tapant `sudo su` ou `sudo -i`.
 
 ## Quels utilisateurs ?
 
-Par défaut, seul l’utilisateur `admin` peut se logger en SSH sur une instance YunoHost.
+Par défaut, seul l'utilisateur `admin` peut se logger en SSH sur une instance YunoHost.
 
-Les utilisateurs YunoHost créés via l’interface d’administration sont gérés par la base de donnée LDAP. Par défaut, ils ne peuvent pas se connecter en SSH pour des raisons de sécurité. Si vous avez absolument besoin qu’un utilisateur dispose d’un accès SSH, vous pouvez leur octroyer ce droit depuis l’interface d’administration~: dans le panneau de gestion des utilisateurs, il y a un bouton `Gérer les groupes et les autorisations`. Pour qu’un utilisateur ai le droit de se connecter en SSH, il suffit de lui ajouter la permission `SSH`.
+Les utilisateurs YunoHost créés via l'interface d'administration sont gérés par la base de donnée LDAP. Par défaut, ils ne peuvent pas se connecter en SSH pour des raisons de sécurité. Si vous avez absolument besoin qu'un utilisateur dispose d'un accès SSH, vous pouvez utiliser la commande :
+```bash
+yunohost user permission add ssh.main <username>
+```
 
+De même, il est possible de supprimer l'accès SSH à un utilisateur avec la commande :
+```bash
+yunohost user permission remove ssh.main <username>
+```
 
-Enfin, il est possible d’ajouter, de supprimer et de lister des clés SSH, pour améliorer la sécurité de l’accès SSH, avec les commandes :
+Enfin, il est possible d'ajouter, de supprimer et de lister des clés SSH, pour améliorer la sécurité de l'accès SSH, avec les commandes :
 ```bash
 yunohost user ssh add-key <username> <key>
 yunohost user ssh remove-key <username> <key>
@@ -89,9 +96,9 @@ Une discussion plus complète de la sécurité et de SSH peut être trouvée sur
 
 ## La ligne de commande Yunohost
 
-!!! Fournir un tutoriel complet sur la ligne de commande est bien au-delà du cadre de la documentation de YunoHost : pour cela, référez-vous à des tutoriels comme [celui-ci](https://doc.ubuntu-fr.org/tutoriel/console_ligne_de_commande) ou [celui-ci (en)](http://linuxcommand.org/). Mais soyez rassuré qu’il n’y a pas besoin d’être un expert pour commencer à l’utiliser !
+!!! Fournir un tutoriel complet sur la ligne de commande est bien au-delà du cadre de la documentation de YunoHost : pour cela, référez-vous à des tutoriels comme [celui-ci](https://doc.ubuntu-fr.org/tutoriel/console_ligne_de_commande) ou [celui-ci (en)](http://linuxcommand.org/). Mais soyez rassuré qu'il n'y a pas besoin d'être un expert pour commencer à l'utiliser !
 
-La commande `yunohost` peut être utilisée pour administrer votre serveur ou réaliser les mêmes actions que celles disponibles sur la webadmin. Elle doit être lancée en depuis l’utilisateur `root`, ou bien depuis l’utilisateur `admin` en précédant la commande de `sudo`. (ProTip™ : il est possible de devenir `root` via la commande `sudo su` en tant qu’`admin`.)
+La commande `yunohost` peut être utilisée pour administrer votre serveur ou réaliser les mêmes actions que celles disponibles sur la webadmin. Elle doit être lancée en depuis l'utilisateur `root`, ou bien depuis l'utilisateur `admin` en précédant la commande de `sudo`. (ProTip™ : il est possible de devenir `root` via la commande `sudo su` en tant qu'`admin`.)
 
 Les commandes YunoHost ont ce type de structure :
 
@@ -102,7 +109,7 @@ yunohost app install wordpress --label Webmail
    categorie  action  argument     options
 ```
 
-N’hésitez pas à naviguer et demander des informations à propos d’une catégorie ou action donnée via l’option `--help`. Par exemple, ces commandes :
+N'hésitez pas à naviguer et demander des informations à propos d'une catégorie ou action donnée via l'option `--help`. Par exemple, ces commandes :
 
 ```bash
 yunohost --help
@@ -110,4 +117,4 @@ yunohost user --help
 yunohost user create --help
 ```
 
-vont successivement lister toutes les catégories disponibles, puis les actions de la catégorie `user`, puis expliquer comment utiliser l’action `user create`. Vous devriez remarquer que l’arbre des commandes YunoHost suit une structure similaire aux pages de la webadmin.
+vont successivement lister toutes les catégories disponibles, puis les actions de la catégorie `user`, puis expliquer comment utiliser l'action `user create`. Vous devriez remarquer que l'arbre des commandes YunoHost suit une structure similaire aux pages de la webadmin.

--- a/pages/01.administrate/06.overview/04.commandline/ssh.fr.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.fr.md
@@ -94,7 +94,7 @@ N.B. : `fail2ban` bannira votre IP pour 10 minutes si vous échouez plus de 5 fo
 
 Une discussion plus complète de la sécurité et de SSH peut être trouvée sur [la page dédiée](/security).
 
-## La ligne de commande Yunohost
+## La ligne de commande YunoHost
 
 !!! Fournir un tutoriel complet sur la ligne de commande est bien au-delà du cadre de la documentation de YunoHost : pour cela, référez-vous à des tutoriels comme [celui-ci](https://doc.ubuntu-fr.org/tutoriel/console_ligne_de_commande) ou [celui-ci (en)](http://linuxcommand.org/). Mais soyez rassuré qu'il n'y a pas besoin d'être un expert pour commencer à l'utiliser !
 

--- a/pages/01.administrate/06.overview/04.commandline/ssh.it.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.it.md
@@ -24,7 +24,7 @@ Se stai installando su un VPS allora il provider dovrebbe averti indicato il tuo
 Se stai installando su un computer casalingo (ad esempio un Raspberry Pi o un OLinuXino) devi individuare l'indirizzo IP che è stato attribuito al computer dopo averlo collegato al router. Questi sono alcuni sistemi:
 - avvia un terminale e dai il comando `sudo arp-scan --local` per elencare gli indirizzi IP sulla rete locale;
 - usa l'interfaccia del router per vedere la lista dei computer collegati o controllane i log;
-- collega un monitor al tuo server yunohost, fai login e digita `hostname --all-ip-address`.
+- collega un monitor al tuo server YunoHost, fai login e digita `hostname --all-ip-address`.
 
 #### Collegamento
 
@@ -98,7 +98,7 @@ N.B.: `fail2ban` bannerà il tuo IP per 10 minuti nel caso di almeno 5 tentativi
 
 Una discussione più approfondita relativa a sicurezza & SSH è su [questa pagina](/security).
 
-## Yunohost command line
+## YunoHost command line
 
 !!! Providing a full tutorial about the command line is quite beyond the scope of the YunoHost documentation : for this, consider reading a dedicated tutorial such as [this one](https://ryanstutorials.net/linuxtutorial/) or [this one](http://linuxcommand.org/). But be reassured that you don't need to be a CLI expert to start using it !
 

--- a/pages/01.administrate/06.overview/04.commandline/ssh.it.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.it.md
@@ -75,13 +75,13 @@ Di default solo l'utente `admin` può loggarsi al server SSH di YunoHost.
 Gli utenti creati dall'interfaccia di amministrazione sono gestiti dalla directory LDAP e di default non possono connettersi via SSH per ragioni di sicurezza. Se invece vuoi abilitare all'accesso SSH alcuni utenti usa il comando:
 
 ```bash
-yunohost user ssh allow <username>
+yunohost user permission add ssh.main <username>
 ```
 
 È sempre possibile eliminare l'accesso SSH con il comando:
 
 ```bash
-yunohost user ssh disallow <username>
+yunohost user permission remove ssh.main <username>
 ```
 
 Infine è possibile aggiungere, eliminare ed elencare le chiavi SSH, usate per migliorare la sicurezza degli accessi SSH con i comandi:

--- a/pages/01.administrate/06.overview/04.commandline/ssh.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.md
@@ -100,7 +100,7 @@ N.B. : `fail2ban` will ban your IP for 10 minutes if you perform 5 failed login 
 
 A more extensive discussion about security & SSH can be found on the [dedicated page](/security).
 
-## Yunohost command line
+## YunoHost command line
 
 !!! Providing a full tutorial about the command line is quite beyond the scope of the YunoHost documentation : for this, consider reading a dedicated tutorial such as [this one](https://ryanstutorials.net/linuxtutorial/) or [this one](http://linuxcommand.org/). But be reassured that you don't need to be a CLI expert to start using it !
 

--- a/pages/01.administrate/06.overview/04.commandline/ssh.md
+++ b/pages/01.administrate/06.overview/04.commandline/ssh.md
@@ -77,13 +77,13 @@ By default, only the `admin` user can log in to YunoHost SSH server.
 YunoHost's users created via the administration interface are managed by the LDAP directory. By default, they can't connect via SSH for security reasons. If you want some users to have SSH access enabled, use the command:
 
 ```bash
-yunohost user ssh allow <username>
+yunohost user permission add ssh.main <username>
 ```
 
 It is also possible to remove SSH access using the following:
 
 ```bash
-yunohost user ssh disallow <username>
+yunohost user permission remove ssh.main <username>
 ```
 
 Finally, it is possible to add, delete and list SSH keys, to improve SSH access security, using the commands:


### PR DESCRIPTION
Mais on peut passer par le panneau d’administration