### PR TITLE
Add Cloudflared to the wishlist (not free software)

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -42,6 +42,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [CheckUp](https://sourcegraph.github.io/checkup) |  | [Upstream](https://github.com/sourcegraph/checkup) |  |
 | [Citadel-suite](https://www.citadel.org) | Groupware platform |  |  |
 | [CloudTube](https://tube.cadence.moe/) | CloudTube front-end for YouTube | [Upstream](https://git.sr.ht/~cadence/cloudtube) |  |
+| [Cloudflared](https://github.com/cloudflare/cloudflared) | Contains the command-line client for Argo Tunnel, a tunneling daemon that proxies any local webserver through the Cloudflare network. This would seriously simplify DNS config for users while also increasing security. | [Upstream](https://github.com/cloudflare/cloudflared/releases) |  |
 | [Cockpit](https://cockpit-project.org/) |  |  | [Package Draft](https://github.com/YunoHost-Apps/cockpit_ynh) |
 | coin | Member dashboard for non profit ISP | [Upstream](https://code.ffdn.org/FFDN/coin/) | [Package Draft](https://github.com/YunoHost-Apps/coin_ynh) |
 | Commafeed |  | [Upstream](https://github.com/Athou/commafeed) |  |


### PR DESCRIPTION
Cloudflared also allows automatic DNS updates with argo tunnels to create proper DNS entries. Unfortunately I lack the experience in order to properly package it and integrate into yunohost.