### PR TITLE
Add Torrents.csv Server to the Apps Wishlist

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -295,6 +295,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | Tinylist |  | [Upstream](https://github.com/baggachipz/tinylist) |  |
 | [TMate](https://tmate.io/) |  | [Upstream](https://github.com/tmate-io/tmate) |  |
 | torrelay |  |  | [Package Draft](https://github.com/matlink/torrelay_ynh) |
+| [Torrents.csv Server](https://torrents-csv.ml/) | search for torrents, or files within torrents | [Upstream](https://codeberg.org/heretic/torrents-csv-server) |  |
 | Tracim |  | [Upstream](https://github.com/tracim/tracim) |  |
 | Traccar | Modern GPS Tracking Platform | [Upstream](https://github.com/traccar/traccar) |  |
 | transpay | Interface to receive and manage donations with Stripe |  | [Package Draft](https://github.com/YunoHost-Apps/transpay_ynh) |


### PR DESCRIPTION
Add Torrents.csv - https://torrents-csv.ml/#/ - a collaborative repository of torrents and their files, consisting of a searchable torrents.csv, and torrent_files.csv. With it you can search for torrents, or files within torrents. It aims to be a universal file system for popular data.