### PR TITLE
Add Access to Memory (AtoM) to the wishlist

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -18,6 +18,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | 2FAuth | Manage and Generate 2FA Codes | [Upstream](https://github.com/Bubka/2FAuth) |  |
 | 10er10 |  | [Upstream](https://github.com/dready92/10er10) |  |
 | [AbanteCart](https://abantecart.com) | Create an e-commerce website |  | [Package Draft](https://github.com/YunoHost-Apps/abantecart_ynh) |
+| [Access to Memory (AtoM)](https://www.accesstomemory.org/) | Web-based, open source application for standards-based archival description and access in a multilingual, multi-repository environment. | [Upstream](https://github.com/artefactual/atom) |  |
 | adhocserver | An ad hoc server for the Sony PSP |  | [Package Draft](https://github.com/matlink/adhocserver_ynh) |
 | [agora](https://www.agora-project.net/) | Create collaborative and creative digital space |  | [Package Draft](https://github.com/YunoHost-Apps/agora_ynh) |
 | [Ajenti](https://ajenti.org) |  | [Upstream](https://github.com/ajenti/ajenti/) |  |


### PR DESCRIPTION
AtoM - https://demo.accesstomemory.org/ - was first commissioned by the International Council on Archives (ICA) to make it easier for archival institutions worldwide to put their holdings online using the ICA’s descriptive standards, the project has since grown into an internationally used community-driven project. License: https://github.com/artefactual/atom/blob/qa/2.x/LICENSE