### PR TITLE
initial doc for Ecko

### DIFF
--- a/pages/02.applications/02.docs/ecko/app_ecko.md
+++ b/pages/02.applications/02.docs/ecko/app_ecko.md
@@ -1,0 +1,39 @@
+---
+title: Ecko
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_ecko'
+---
+
+![Ecko's logo](image://ecko_logo.jpg)
+
+[![Install APPLICATION with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=ecko) [![Integration level](https://dash.yunohost.org/integration/ecko.svg)](https://dash.yunohost.org/appci/app/ecko)
+
+### Index
+
+- [Limitations with YunoHost](#limitations-with-yunohost)
+- [Useful links](#useful-links)
+- [Compatible Apps](#compatible-apps)
+
+Ecko is community-driven fork of Mastodon's federated social network software that is managed by the Magic Stone community using the Collaborative Code Construction Contract (C4).
+
+## Limitations with YunoHost
+
+Some configuration parameters such as post-length and poll options can only be updated via command line and therefore require root command line access to the YunoHost instance to modify.
+
+## Useful links
+
++ Website: [magicstone.dev](https://magicstone.dev/)
++ YunoHost application package repository: [github.com - YunoHost-Apps/Ecko\_ynh](https://github.com/YunoHost-Apps/ecko_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com -YunoHost-Apps/ecko_ynh/issues](https://github.com/YunoHost-Apps/ecko_ynh/issues)
+
+## Compatible Apps
+https://tusky.app/
+https://twidere.com/
+https://fedilab.app/
+https://apps.apple.com/us/app/mastodon-for-iphone/id1571998974
+https://apps.apple.com/us/app/mast-for-mastodon/id1437429129
+https://apps.apple.com/us/app/mercury-for-mastodon/id1486749200
+


### PR DESCRIPTION
As Ecko is a new package there is no doc, so this PR adds one.

Related: https://github.com/magicstone-dev/ecko/issues/268