### PR TITLE
Add Open Streaming Platform to the wishlist

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -199,6 +199,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | openid-simplesamlphp | OpenID provider based on SimpleSAMLphp |  | [Package Draft](https://github.com/julienmalik/openid-simplesamlphp_ynh) |
 | openproject |  | [Upstream](https://github.com/opf/openproject) | [Package Draft](https://github.com/moutonjr/openproject_ynh) |
 | OpenSourceBilling |  | [Upstream](https://github.com/vteams/open-source-billing) |  |
+| [Open Streaming Platform](https://openstreamingplatform.com/) | A self-hosted video streaming and recording server using Python, Flask, Nginx-RTMP | [Upstream](https://gitlab.com/osp-group/flask-nginx-rtmp-manager) |  |
 | [osjs](https://www.os-js.org/) | Desktop you have access to through your web-browser |  | [Package Draft](https://github.com/YunoHost-Apps/osjs_ynh) |
 | [osmw](https://www.openstreetmap.org/) | Cartography software |  | [Package Draft](https://github.com/YunoHost-Apps/osmw_ynh) |
 | OSRM |  | [Upstream](https://github.com/Project-OSRM/osrm-backend) |  |


### PR DESCRIPTION
The Open Streaming Platform - https://openstreamingplatform.com/ - was designed as a self-hosted alternative to services such as Twitch.tv, Ustream.tv, Mixer, and Youtube Live' and is a Live Streaming App. Use the demo server to test OSP at https://demo.openstreamingplatform.com/