### PR TITLE
Update port forwarding directions

### DIFF
--- a/pages/01.administrate/05.install/03.isp_box_config/isp_box_config.md
+++ b/pages/01.administrate/05.install/03.isp_box_config/isp_box_config.md
@@ -58,3 +58,4 @@ A technology called UPnP is available on some internet boxes / routers and allow
 sudo yunohost firewall reload
 ```
 
+On some routers, UPnP can actually get in the way. If some or all ports are inaccessible from outside your network, try turning UPnP off in your router's settings and setting up port forwarding manually. You can easily test port accessibility using tools like [CanYouSeeMe](https://canyouseeme.org/).


### PR DESCRIPTION
On some routers (tested on a [Spectrum 6](https://d15yx0mnc9teae.cloudfront.net/sites/default/files/WiFi-6-Guide-1-7-21.pdf)), UPnP caused certain ports to be inaccessible, regardless of `sudo yunohost firewall reload` or manual port forwarding rules. turning UPnP off solved the problem.