### PR TITLE
Update doc for setting PasswordAuthentication to 'no'

### DIFF
--- a/pages/01.administrate/06.overview/12.security/security.fr.md
+++ b/pages/01.administrate/06.overview/12.security/security.fr.md
@@ -50,17 +50,10 @@ ssh-copy-id -i ~/.ssh/id_rsa.pub <nom_utilisateur@votre.domaine.tld>
 
 Entrez le mot de passe d’administration et votre clé publique devrait être copiée sur votre serveur.
 
-**Sur votre serveur**, éditez le fichier de configuration SSH, pour désactiver l’authentification par mot de passe.
-```bash
-nano /etc/ssh/sshd_config
+**Sur votre serveur**, l'édition du fichier de configuration SSH pour désactiver l’authentification par mot de passe est gérée par un paramètre système :
 
-# Modifiez ou ajoutez la ligne suivante
-PasswordAuthentication no
-```
-
-Sauvegardez et relancez le démon SSH.
 ```bash
-systemctl restart ssh
+sudo yunohost settings set security.ssh.password_authentication -v no
 ```
 
 ---

--- a/pages/01.administrate/06.overview/12.security/security.md
+++ b/pages/01.administrate/06.overview/12.security/security.md
@@ -46,18 +46,10 @@ ssh-copy-id -i ~/.ssh/id_rsa.pub <username@your_yunohost_server>
 
 Type your admnistration password and your key will be copied on your server.
 
-**On your server**, edit the SSH configuration file, in order to deactivate the password authentication.
+**On your server**, the edition of the SSH configuration file in order to deactivate the password authentication is handled by a system setting:
 
 ```bash
-nano /etc/ssh/sshd_config
-
-# Modify or add the following line
-PasswordAuthentication no
-```
-
-Save and restart the SSH daemon.
-```bash
-systemctl restart ssh
+sudo yunohost settings set security.ssh.password_authentication -v no
 ```
 ---
 


### PR DESCRIPTION
In the file ssh config file (` /etc/ssh/sshd_config`), it says that one should call `yunohost settings set security.ssh.password_authentication -v no` in order to deactivate password authentication. But the documentation still explains the older method (editing the config file by hand). This PR updates the documentation so it is consistent with the configuration file.