### PR TITLE
Fix image src

### DIFF
--- a/pages/01.administrate/07.specific_use_cases/01.domains/04.dns_local_network/dns_local_network.md
+++ b/pages/01.administrate/07.specific_use_cases/01.domains/04.dns_local_network/dns_local_network.md
@@ -27,12 +27,12 @@ The goal here is to create a network wide redirection handled by your router. Th
 ### SFR Box
 If you haven't found your server private IP, you may find it using the SFR box admin panel:  
     Go to Network tab > General
-<img src="/images/ip_serveur.png" width=800>
+<img src="/user/images/ip_serveur.png" width=800>
 
 #### Configure SFR box's DNS
 
 Go to Network tab > DNS and add your domain name to the box's DNS.
-<img src="/images/dns_9box.png" width=800>
+<img src="/user/images/dns_9box.png" width=800>
 
 ## Configure [hosts](https://en.wikipedia.org/wiki/Host_%28Unix%29) file on client workstation
 


### PR DESCRIPTION
Not sure if this actually fixes it, but I can't create issues. Anyway, the images on [Local network access to your server](https://yunohost.org/en/dns_local_network) link to `https://yunohost.org/images/ip_serveur.png` which is broken. Prepending `/user`, like this: `https://yunohost.org/user/images/ip_serveur.png` seems to fix it.