### PR TITLE
Add Hashbase

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -113,6 +113,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [Greenlight](https://blabla.aquilenet.fr/b) | A really simple end-user interface for your BigBlueButton server | [Upstream](https://github.com/bigbluebutton/greenlight) |  |
 | [Grist](https://www.getgrist.com/) | The evolution of spreadsheets | [Upstream](https://github.com/gristlabs/grist-core/) |  |
 | [Habitica](https://habitica.com/) |  | [Upstream](https://github.com/HabitRPG/habitica) |  |
+| [Hashbase](https://github.com/beakerbrowser/hashbase/tree/master/docs) | A public peer service for Dat archives, provides a HTTP-accessible interface for creating an account and uploading Dats. | [Upstream](https://github.com/beakerbrowser/hashbase) |  |
 | Helpy |  | [Upstream](https://github.com/helpyio/helpy) |  |
 | [Hexo](https://hexo.io/) |  | [Upstream](https://github.com/hexojs/hexo) |  |
 | Hometown |  | [Upstream](https://github.com/hometown-fork/hometown) |  |


### PR DESCRIPTION
Hashbase is a public peer service for Dat archives. It provides a HTTP-accessible interface for creating an account and uploading Dats. It was created to power a content-community for the Beaker Browser. The license for the source code is available at https://github.com/beakerbrowser/hashbase/blob/master/LICENSE and a demo website made with TiddlyWiki and hosted with Hashbase is available at https://tromsitegr.hashbase.io/#:HOME .