### PR TITLE
Install documentation - complete a TODO mark with a CLI screenshot

### DIFF
--- a/pages/01.administrate/05.install/install.fr.md
+++ b/pages/01.administrate/05.install/install.fr.md
@@ -561,7 +561,7 @@ Allez dans `Utilisateurs > Nouvel utilisateur`.
 ```
 yunohost user create johndoe
 ```
-TODO : copypasta an actual shell session will all info asked etc..
+[ynh_usercreate_cli](image://create-first-user-cli.png?resize=100%&class=inline)
 
 [/ui-tab]
 [/ui-tabs]


### PR DESCRIPTION
Simply added an URL of the same format than the other pictures of the page and removed the corresponding TODO mark
Not sure where to upload the related picture here attached though

![create-first-user-cli](https://user-images.githubusercontent.com/59071673/170145183-1e4351bf-1892-46d9-b5c6-d8d90cbdc711.png)
 