### PR TITLE
Add Farside

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -78,6 +78,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [EteSync](https://www.etesync.com/) |  | [Upstream](https://github.com/etesync) |  |
 | [Excalibur](https://excalibur-py.readthedocs.io/en/master/) | A web interface to extract tabular data from PDFs (based on Camelot) | [Upstream](https://github.com/camelot-dev/excalibur) | |
 | [Fab Manager](https://www.fab-manager.com/) | Simplify the daily management of your Third place/Fablab and boost your community | [Upstream](https://github.com/sleede/fab-manager) | |
+| [Farside](https://farside.link/) | A redirecting service for FOSS alternative frontends | [Updtream](https://github.com/benbusby/farside) |  |
 | [Federated wiki](http://fed.wiki.org/view/welcome-visitors/view/federated-wiki) | Farm for fedwiki sites | [Upstream](https://github.com/fedwiki) |  |
 | [Ferdi server](https://getferdi.com) | Messaging aggregation | [Upstream](https://github.com/getferdi/server) |  |
 | [FEX](https://fex.rus.uni-stuttgart.de/) |  |  |  |


### PR DESCRIPTION
Farside - https://farside.link/ provides links that automatically redirect to working instances of privacy-oriented alternative frontends, such as Nitter, Libreddit, etc. The Farside's links work with the following structure: farside.link/<service>/<path>
This allows for users to have more reliable access to the available public instances for a particular service, while also helping to distribute traffic more evenly across all instances and avoid performance bottlenecks and rate-limiting. The license is available at https://github.com/benbusby/farside/blob/main/LICENSE and you can test the demo redirects at https://github.com/benbusby/farside#demo