### PR TITLE
Add WikiSuite

### DIFF
--- a/pages/02.applications/04.wishlist/apps_wishlist.md
+++ b/pages/02.applications/04.wishlist/apps_wishlist.md
@@ -305,6 +305,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [WebThings Gateway](https://iot.mozilla.org/gateway/) |  | [Upstream](https://github.com/mozilla-iot/) |  |
 | Whoogle | A metasearch engine | [Upstream](https://github.com/benbusby/whoogle-search) |  |
 | [Wikiless](https://wikiless.org/) | A free open source alternative Wikipedia front-end focused on privacy. | [Upstream](https://codeberg.org/orenom/wikiless) |  |
+| [WikiSuite](https://wikisuite.org/Software) | The most comprehensive and integrated Open Source enterprise solution. | [Upstream](https://gitlab.com/wikisuite) |  |
 | [wildfly](https://wildfly.org) |  |  | [Package Draft](https://github.com/YunoHost-Apps/wildfly_ynh) |
 | Wisemapping | An online mind mapping editor | [Upstream](https://bitbucket.org/wisemapping/wisemapping-open-source) | [Package Draft](https://github.com/YunoHost-Apps/wisemapping_ynh) |
 | WildDuck | Opinionated email server | [Upstream](https://github.com/nodemailer/wildduck) |  |


### PR DESCRIPTION
While Wikipedia is the broadest unified body of knowledge, WikiSuite - https://wikisuite.org is the most comprehensive and integrated Open Source enterprise solution. According to https://wikisuite.org/License : "All Software Components are released under an OSI-approved license. Please see each component page for the specific license." - https://wikisuite.org/Software-Components
It can be installed in a similar way the YunoHost uses, on a fresh minimal Debian 10 server ( https://wikisuite.org/How-to-install-WikiSuite ), but it would be really awesome to be installed from YunoHost, using the apps already packaged.