### PR TITLE
jitsi: link to electron app

### DIFF
--- a/pages/02.applications/02.docs/jitsi/app_jitsi.md
+++ b/pages/02.applications/02.docs/jitsi/app_jitsi.md
@@ -32,7 +32,7 @@ Jitsi for YunoHost for now as some limitations:
 | Application name | Platform | Multi-account | Other supported networks | Play Store | F-Droid | Apple Store | *Other* |
 |-----------------------|------------|---------------|-------------------------|------------|---------|-------------|----------|
 | Jitsi Meet            | Android - iOS  |               |                      | [Jitsi Meet](https://play.google.com/store/apps/details?id=org.jitsi.meet) | [Jitsi Meet](https://f-droid.org/en/packages/org.jitsi.meet/) | [Jitsi Meet](https://apps.apple.com/us/app/jitsi-meet/id1165103905) |          |
-| Jitsi Meet Desktop    | Windows - macOS - GNU/Linux  |  |                        |            |         |             | [Download](https://desktop.jitsi.org/Main/Download)  |
+| Jitsi Meet Electron   | Windows - macOS - GNU/Linux  |  |                        |            |         |             | [Download](https://github.com/jitsi/jitsi-meet-electron)  |
 
 ## Useful links
 


### PR DESCRIPTION
The Jitsi Desktop is a legacy SIP app not working with Jitsi Meet, replace with the Electron-based app.