### PR TITLE
Add reminder about domains and subdomains

### DIFF
--- a/pages/02.administer/15.admin_guide/25.domains/domains.de.md
+++ b/pages/02.administer/15.admin_guide/25.domains/domains.de.md
@@ -21,6 +21,11 @@ Beachten Sie abschließend, dass es im Kontext von YunoHost keine Hierarchie zwi
 
 Wenn Ihre Domain spezielle, nicht-lateinische Zeichen enthält, müssen Sie ihre [internationalisierte Version](https://de.wikipedia.org/wiki/Internationalisierter_Domainname) über [Punycode](https://de.wikipedia.org/wiki/Punycode) verwenden. Sie können [diesen Konverter](https://www.charset.org/punycode) verwenden und den konvertierten Domainnamen in Ihrer YunoHost-Konfiguration verwenden. 
 
+## Subdomains
+
+! Bitte beachten Sie, dass YunoHost Domains und deren Subdomains unabhängig voneinander betrachtet.
+! Sie **müssen** alle Domains und Subdomains, die Sie nutzen möchten, registrieren.
+
 ## DNS-Konfiguration
 
 DNS (Domain Name System) ist ein System, das es Computern auf der ganzen Welt ermöglicht, von Menschen lesbare Domain-Namen (wie z.B. `yolo.com`) in maschinenverständliche Adressen, sogenannte IP-Adressen (wie z.B. `11.22.33.44`), zu übersetzen. Damit diese Übersetzung (und andere Funktionen) funktioniert, müssen Sie DNS-Einträge sorgfältig konfigurieren. 

--- a/pages/02.administer/15.admin_guide/25.domains/domains.fr.md
+++ b/pages/02.administer/15.admin_guide/25.domains/domains.fr.md
@@ -35,6 +35,11 @@ Le chiffre risque de changer selon quel serveur démarre en premier, donc ne com
 ! Malheureusement, les appareils Android avant la version 12 (sortie en 2021) ne semblent pas écouter le protocole mDNS.
 ! Pour profiter des domaines `.local` sur vos appareils Android, vous devez entrer l'adresse IP locale de votre serveur YunoHost dans leur paramètre DNS.
 
+## Sous-domaines
+
+! Gardez bien en tête que YunoHost considère les domaines et leur sous-domaines indépendamment.
+! **Il vous faut** enregistrer chacun des domaines et sous-domaines que vous voulez utiliser.
+
 ## Configuration DNS
 
 DNS (Domain Name System) est un système qui permet aux ordinateurs du monde entier de traduire les noms de domaine lisibles par l'homme (comme `yolo.com`) en adresses IP compréhensibles par les machines (comme `11.22.33.44`). Pour que cette traduction (et d'autres fonctionnalités) fonctionne, il faut configurer soigneusement les enregistrements DNS. 

--- a/pages/02.administer/15.admin_guide/25.domains/domains.md
+++ b/pages/02.administer/15.admin_guide/25.domains/domains.md
@@ -89,6 +89,11 @@ The domain chosen during the initial configuration (post-install) is defined as 
 
 More technically, the main domain is also used as hostname by SMTP protocol to send email (EHLO) and determine which value should be configured in the reverse DNS bind to your public IP. If this 2 values are mis-configured, the diagnosis tool will trigger you an alert.
 
+## Subdomains
+
+! Bear in mind, YunoHost considers domains and their subdomains independently.
+! You **need** to register all the domains and subdomains you want to use.
+
 ## About Non-latin characters
 
 If your domain has special, non-latin characters, it will be transformed by YunoHost into its [internationalized version](https://en.wikipedia.org/wiki/Internationalized_domain_name) through [Punycode](https://en.wikipedia.org/wiki/Punycode). So when you use the command line, you have to use the punycode format return for example by `yunohost domain list`.


### PR DESCRIPTION
Add a kind reminder that domains and subdomains must all be registered within YunoHost. (Registering domains do not assume all their subdomains, especially for certificates).