### PR TITLE
Add Flus(io) to wishlist

### DIFF
--- a/pages/04.applications/99.wishlist/apps_wishlist.md
+++ b/pages/04.applications/99.wishlist/apps_wishlist.md
@@ -92,6 +92,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [fishnet](https://lichess.org/get-fishnet) | Distributed Stockfish analysis for lichess.org | [Upstream](https://github.com/niklasf/fishnet) |  |
 | FitTrackee |  | [Upstream](https://github.com/SamR1/FitTrackee) |  |
 | Flask | Skeleton for flask apps |  | [Package Draft](https://github.com/YunoHost-Apps/flask_ynh) |
+| [Flus](https://flus.fr/) | Aggregate, save and share links from all over the Web.  | [Upstream](https://github.com/flusio/flusio) | |
 | [foodsoft](https://foodcoops.github.io/foodsoft-hosting/) | Manage a non-profit food cooperative |  | [Package Draft](https://github.com/YunoHost-Apps/foodsoft_ynh) |
 | [Fossil](https://www.fossil-scm.org) |  |  |  |
 | full-text-rss |  | [Upstream](https://bitbucket.org/fivefilters/full-text-rss/src/master/) |  |


### PR DESCRIPTION
This sounds like a very nicely designed app with special attention given to the UI/UX, a fresh look on RSS-reader and the like

On the other hand, the dev seems to be struggling to try to create a viable economic model based on selling Flus as SaaS : https://flus.fr/tarifs 

Which makes me think we should probably add a `support` key in the manifests to store and URL where people can support their favorite apps, and advertise those links from our webadmin

Edit: https://github.com/YunoHost/apps/commit/0ab409fbd0f2157cd23e5ee3ef9a780e00c0dabf as a followup