### PR TITLE
Update buster_bullseye_migration.md

### DIFF
--- a/pages/02.administer/15.admin_guide/55.upgrade/15.buster_bullseye/buster_bullseye_migration.md
+++ b/pages/02.administer/15.admin_guide/55.upgrade/15.buster_bullseye/buster_bullseye_migration.md
@@ -93,7 +93,7 @@ yunohost app upgrade --force APP_NAME
 ## Current known issues after the migration
 
 ### Can't run the migration due to `libc6-dev : Breaks: libgcc-8-dev issue`.
-
+Note: This issue should be resolved in yunohost_version: 4.4.2.13
 You have an app that depends of build-essential package.
 
 See this [solution](https://forum.yunohost.org/t/migration-to-11-wont-start-libc6-dev-breaks-libgcc-8-dev/20617/42) to fix it manually


### PR DESCRIPTION
Clarify resolution of libc6-dev issue in yunohost_version: 4.4.2.13 so that future migrators don't put the fix in manually before the migration, hosing their systems, as I did mine.