### PR TITLE
Init. of missing docs up to the letter Z

### DIFF
--- a/pages/04.applications/10.docs/teampass/app_teampass.fr.md
+++ b/pages/04.applications/10.docs/teampass/app_teampass.fr.md
@@ -1,0 +1,33 @@
+---
+title: TeamPass
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_teampass'
+---
+
+[![Installer TeamPass avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=teampass) [![Integration level](https://dash.yunohost.org/integration/teampass.svg)](https://dash.yunohost.org/appci/app/teampass)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*TeamPass* est un gestionnaire de mots de passe dédié à la gestion des mots de passe de manière collaborative en les partageant entre les membres d'une équipe. Teampass offre un large ensemble de fonctionnalités permettant de gérer vos mots de passe et les données associées de manière organisée dans le respect des droits d'accès définis pour chaque utilisateur.
+
+### Captures d'écran
+
+![Capture d'écran de Teampass](https://github.com/YunoHost-Apps/teampass_ynh/blob/master/doc/screenshots/screenshot.png)
+
+### Avertissements / informations importantes
+
+### Configuration
+
+Utilisez le panel admin de votre teampass pour configurer cette app.  
+Pour trouver le panel admin, utiliser le login 'admin' et le mot de passe choisi durant l'installation.
+
+## Liens utiles
+
++ Site web : [teampass.net](https://teampass.net/)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/teampass](https://github.com/YunoHost-Apps/teampass_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/teampass/issues](https://github.com/YunoHost-Apps/teampass_ynh/issues)

--- a/pages/04.applications/10.docs/teampass/app_teampass.md
+++ b/pages/04.applications/10.docs/teampass/app_teampass.md
@@ -1,0 +1,34 @@
+---
+title: TeamPass
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_teampass'
+---
+
+[![Installer TeamPass with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=teampass) [![Integration level](https://dash.yunohost.org/integration/teampass.svg)](https://dash.yunohost.org/appci/app/teampass)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*TeamPass* is a Passwords Manager dedicated for managing passwords in a collaborative way by sharing them among team members.
+Teampass offers a large set of features permitting to manage your passwords and related data in an organized way in respect to the access rights defined for each users.
+
+### Screenshots
+
+![Screenshot of Teampass](https://github.com/YunoHost-Apps/teampass_ynh/blob/master/doc/screenshots/screenshot.png)
+
+### Disclaimers / important information
+
+### Configuration
+
+Use the admin panel of your teampass to configure this app.  
+To find the admin panel, use the login 'admin' and the password choose during the installation.
+
+## Useful links
+
++ Website: [teampass.net](https://teampass.net/)
++ Application software repository: [github.com - YunoHost-Apps/teampass](https://github.com/YunoHost-Apps/teampass_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/teampass/issues](https://github.com/YunoHost-Apps/teampass_ynh/issues)

--- a/pages/04.applications/10.docs/thelounge/app_thelounge.fr.md
+++ b/pages/04.applications/10.docs/thelounge/app_thelounge.fr.md
@@ -1,0 +1,33 @@
+---
+title: The Lounge
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_thelounge'
+---
+
+[![Installer The Lounge avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=thelounge) [![Integration level](https://dash.yunohost.org/integration/thelounge.svg)](https://dash.yunohost.org/appci/app/thelounge)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*The Lounge* est un client web IRC moderne conçu pour l'auto-hébergement.
+
+#### Caractéristiques:
+
+- Toujours connecté
+- Interface réactive
+- Support multi-utilisateurs 
+
+### Captures d'écran
+
+![Captures d'écran de The Lounge](https://github.com/YunoHost-Apps/thelounge_ynh/blob/master/doc/screenshots/thelounge-screenshot.png)
+
+## Liens utiles
+
++ Site web : [thelounge.chat](https://thelounge.chat/)
++ Démonstration : [Démo](https://demo.thelounge.chat)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/thelounge](https://github.com/YunoHost-Apps/thelounge_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/thelounge/issues](https://github.com/YunoHost-Apps/thelounge_ynh/issues)

--- a/pages/04.applications/10.docs/thelounge/app_thelounge.md
+++ b/pages/04.applications/10.docs/thelounge/app_thelounge.md
@@ -1,0 +1,33 @@
+---
+title: The Lounge
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_thelounge'
+---
+
+[![Installer The Lounge with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=thelounge) [![Integration level](https://dash.yunohost.org/integration/thelounge.svg)](https://dash.yunohost.org/appci/app/thelounge)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*The Lounge* is a modern web IRC client designed for self-hosting 
+
+### Features:
+
+- Always connected
+- Responsive interface
+- Multi-user support
+
+### Screenshots
+
+![Screenshots of The Lounge](https://github.com/YunoHost-Apps/thelounge_ynh/blob/master/doc/screenshots/thelounge-screenshot.png)
+
+## Useful links
+
++ Website: [thelounge.chat](https://thelounge.chat/)
++ Demonstration: [Demo](https://demo.thelounge.chat)
++ Application software repository: [github.com - YunoHost-Apps/thelounge](https://github.com/YunoHost-Apps/thelounge_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/thelounge/issues](https://github.com/YunoHost-Apps/thelounge_ynh/issues)

--- a/pages/04.applications/10.docs/tiddlywiki/app_tiddlywiki.fr.md
+++ b/pages/04.applications/10.docs/tiddlywiki/app_tiddlywiki.fr.md
@@ -1,0 +1,37 @@
+---
+title: TiddlyWiki
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_tiddlywiki'
+---
+
+[![Installer TiddlyWiki avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=tiddlywiki) [![Integration level](https://dash.yunohost.org/integration/tiddlywiki.svg)](https://dash.yunohost.org/appci/app/tiddlywiki)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*TiddlyWiki* est un wiki interactif complet en JavaScript. Il peut être utilisé comme un simple fichier HTML dans le navigateur ou comme une puissante application Node.js. Il est hautement personnalisable : toute l'interface utilisateur est elle-même implémentée en WikiText paramétrable.
+
+### Captures d'écran
+
+![Capture d'écran de TiddlyWiki](https://github.com/YunoHost-Apps/tiddlywiki_ynh/blob/master/doc/screenshots/screenshot.png)
+
+### Avertissements / informations importantes
+
+### Sauvez your Tiddlers !
+
+Il est très important que vous sauvegardiez régulièrement vos notes (tiddlers) localement.
+
+- Cliquez sur l'icône du nuage -> `Save snapshot for offline use`.
+
+Pour restaurer une sauvegarde locale sur le serveur, glissez et déposez votre fichier de sauvegarde des tiddlers dans votre page TiddlyWiki.
+
+## Liens utiles
+
++ Site web : [tiddlywiki.com](https://tiddlywiki.com/)
++ Démonstration : [Démo](https://tiddlywiki.com/)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/tiddlywiki](https://github.com/YunoHost-Apps/tiddlywiki_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/tiddlywiki/issues](https://github.com/YunoHost-Apps/tiddlywiki_ynh/issues)

--- a/pages/04.applications/10.docs/tiddlywiki/app_tiddlywiki.md
+++ b/pages/04.applications/10.docs/tiddlywiki/app_tiddlywiki.md
@@ -1,0 +1,37 @@
+---
+title: TiddlyWiki
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_tiddlywiki'
+---
+
+[![Installer TiddlyWiki with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=tiddlywiki) [![Integration level](https://dash.yunohost.org/integration/tiddlywiki.svg)](https://dash.yunohost.org/appci/app/tiddlywiki)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*TiddlyWiki* is a complete interactive wiki in JavaScript. It can be used as a single HTML file in the browser or as a powerful Node.js application. It is highly customisable: the entire user interface is itself implemented in hackable WikiText.
+
+### Screenshots
+
+![Screenshot of TiddlyWiki](https://github.com/YunoHost-Apps/tiddlywiki_ynh/blob/master/doc/screenshots/screenshot.png)
+
+### Disclaimers / important information
+
+### Save your Tiddlers!
+
+It is very important that you regularly backup your notes (tiddlers) locally.
+
+- Click on the cloud icon -> `Save snapshot for offline use`
+
+To restore a local backup to the server, drag and drop your tiddlers backup file into your TiddlyWiki page.
+
+## Useful links
+
++ Website: [tiddlywiki.com](https://tiddlywiki.com/)
++ Demonstration: [Demo](https://tiddlywiki.com/)
++ Application software repository: [github.com - YunoHost-Apps/tiddlywiki](https://github.com/YunoHost-Apps/tiddlywiki_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/tiddlywiki/issues](https://github.com/YunoHost-Apps/tiddlywiki_ynh/issues)

--- a/pages/04.applications/10.docs/trilium/app_trilium.fr.md
+++ b/pages/04.applications/10.docs/trilium/app_trilium.fr.md
@@ -1,0 +1,33 @@
+---
+title: Trilium Notes
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_trilium'
+---
+
+[![Installer Trilium Notes avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=trilium) [![Integration level](https://dash.yunohost.org/integration/trilium.svg)](https://dash.yunohost.org/appci/app/trilium)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*Trilium Notes* est une application de prise de note hiérarchique semblable à Evernote, avec maintes fonctions avancées, centrée sur la construction d'une large base de connaissances personnelles.
+
+### Captures d'écran
+
+![Capture d'écran de Trilium Notes](https://github.com/YunoHost-Apps/trilium_ynh/blob/master/doc/screenshots/screenshot.png)
+![Capture d'écran de Trilium Notes](https://github.com/YunoHost-Apps/trilium_ynh/blob/master/doc/screenshots/example.jpg)
+
+### Avertissements / informations importantes
+
+### Configuration
+
+On vous demandera de choisir un nom d'utilisateur et mot de passe quand vous installez l'application. Vous pouvez configurer Trillium depuis le menu de configuration de l'interface web.
+
+## Liens utiles
+
++ Site web : [github.com/zadam/trilium](https://github.com/zadam/trilium)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/trilium](https://github.com/YunoHost-Apps/trilium_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/trilium/issues](https://github.com/YunoHost-Apps/trilium_ynh/issues)

--- a/pages/04.applications/10.docs/trilium/app_trilium.md
+++ b/pages/04.applications/10.docs/trilium/app_trilium.md
@@ -1,0 +1,33 @@
+---
+title: Trilium Notes
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_trilium'
+---
+
+[![Installer Trilium Notes with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=trilium) [![Integration level](https://dash.yunohost.org/integration/trilium.svg)](https://dash.yunohost.org/appci/app/trilium)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*Trilium Notes* is an Evernote-like hierarchical note taking application with many advanced features, focused on building a large personal knowledge base.
+
+### Screenshots
+
+![Screenshot of Trilium Notes](https://github.com/YunoHost-Apps/trilium_ynh/blob/master/doc/screenshots/screenshot.png)
+![Screenshot of Trilium Notes](https://github.com/YunoHost-Apps/trilium_ynh/blob/master/doc/screenshots/example.jpg)
+
+### Disclaimers / important information
+
+### Configuration
+
+You will be asked to choose a username and password when you first access the app. You can configure Trillium from the settings menu of the app interface.
+
+## Useful links
+
++ Website: [github.com/zadam/trilium](https://github.com/zadam/trilium)
++ Application software repository: [github.com - YunoHost-Apps/trilium](https://github.com/YunoHost-Apps/trilium_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/trilium/issues](https://github.com/YunoHost-Apps/trilium_ynh/issues)

--- a/pages/04.applications/10.docs/tyto/app_tyto.fr.md
+++ b/pages/04.applications/10.docs/tyto/app_tyto.fr.md
@@ -1,0 +1,26 @@
+---
+title: Tyto
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_tyto'
+---
+
+[![Installer Tyto avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=tyto) [![Integration level](https://dash.yunohost.org/integration/tyto.svg)](https://dash.yunohost.org/appci/app/tyto)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*Tyto* est un outil de gestion et d'organisation extensible et personnalisable.
+
+### Captures d'écran
+
+![Captures d'écran](https://github.com/YunoHost-Apps/tyto_ynh/blob/master/doc/screenshots/screenshot.png)
+
+## Liens utiles
+
++ Site web : [jh3y.github.io/tyto](https://jh3y.github.io/tyto/)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/tyto](https://github.com/YunoHost-Apps/tyto_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/tyto/issues](https://github.com/YunoHost-Apps/tyto_ynh/issues)

--- a/pages/04.applications/10.docs/tyto/app_tyto.md
+++ b/pages/04.applications/10.docs/tyto/app_tyto.md
@@ -1,0 +1,26 @@
+---
+title: Tyto
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_tyto'
+---
+
+[![Installer Tyto with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=tyto) [![Integration level](https://dash.yunohost.org/integration/tyto.svg)](https://dash.yunohost.org/appci/app/tyto)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*Tyto* is an extensible and customizable management and organisation tool.
+
+## Screenshots
+
+![Screenshots](https://github.com/YunoHost-Apps/tyto_ynh/blob/master/doc/screenshots/screenshot.png)
+
+## Useful links
+
++ Website: [jh3y.github.io/tyto](https://jh3y.github.io/tyto/)
++ Application software repository: [github.com - YunoHost-Apps/tyto](https://github.com/YunoHost-Apps/tyto_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/tyto/issues](https://github.com/YunoHost-Apps/tyto_ynh/issues)

--- a/pages/04.applications/10.docs/vikunja/app_vikunja.fr.md
+++ b/pages/04.applications/10.docs/vikunja/app_vikunja.fr.md
@@ -1,0 +1,44 @@
+---
+title: Vikunja
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_vikunja'
+---
+
+[![Installer Vikunja avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vikunja) [![Integration level](https://dash.yunohost.org/integration/vikunja.svg)](https://dash.yunohost.org/appci/app/vikunja)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*Vikunja* est une application de liste de tâches Open Source auto-hébergée pour toutes les plateformes.
+
+### Caractéristiques
+
+- Restez organisé 
+- Collaborez avec vos pairs
+- Tâches  
+- Tableau Kanban
+- CalDAV
+- Liens
+
+### Captures d'écran
+
+![Capture d'écran de Vikunja](https://github.com/YunoHost-Apps/vikunja_ynh/blob/master/doc/screenshots/kanban.png)
+
+### Avertissements / informations importantes
+
+### Configuration
+
+Vous pouvez configurer Vikunja avec les config panels ou en modifiant le fichier `/opt/vikunja/config.yml` en vous aidant de la [documentation](https://vikunja.io/docs/config-options/).
+
+L'API est accessible par le lien suivant : https://domain.ltd/api/v1/docs.
+
+## Liens utiles
+
++ Site web : [vikunja.io](https://vikunja.io/)
++ Démonstration : [Démo](https://try.vikunja.io/login)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/vikunja](https://github.com/YunoHost-Apps/vikunja_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/vikunja/issues](https://github.com/YunoHost-Apps/vikunja_ynh/issues)

--- a/pages/04.applications/10.docs/vikunja/app_vikunja.md
+++ b/pages/04.applications/10.docs/vikunja/app_vikunja.md
@@ -1,0 +1,44 @@
+---
+title: Vikunja
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_vikunja'
+---
+
+[![Installer Vikunja with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=vikunja) [![Integration level](https://dash.yunohost.org/integration/vikunja.svg)](https://dash.yunohost.org/appci/app/vikunja)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*Vikunja* is a self-hosted open-source to-do list application for all platforms.
+
+### Features
+
+- Stay organized 
+- Collaborate with peers
+- Tasks  
+- Kanban board
+- CalDAV
+- Links
+
+### Screenshots
+
+![Screenshot of Vikunja](https://github.com/YunoHost-Apps/vikunja_ynh/blob/master/doc/screenshots/kanban.png)
+
+### Disclaimers / important information
+
+### Configuration
+
+You can configure Vikunja with the config panels in the webadmin or by editing this file `/opt/vikunja/config.yml` using the [documentation](https://vikunja.io/docs/config-options/).
+
+The API is accesible with this path: https://domain.ltd/api/v1/docs.
+
+## Useful links
+
++ Website: [vikunja.io](https://vikunja.io/)
++ Demonstration: [Demo](https://try.vikunja.io/login)
++ Application software repository: [github.com - YunoHost-Apps/vikunja](https://github.com/YunoHost-Apps/vikunja_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/vikunja/issues](https://github.com/YunoHost-Apps/vikunja_ynh/issues)

--- a/pages/04.applications/10.docs/wemawema/app_wemawema.fr.md
+++ b/pages/04.applications/10.docs/wemawema/app_wemawema.fr.md
@@ -1,0 +1,27 @@
+---
+title: WemaWema
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_wemawema'
+---
+
+[![Installer WemaWema avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=wemawema) [![Integration level](https://dash.yunohost.org/integration/wemawema.svg)](https://dash.yunohost.org/appci/app/wemawema)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*WemaWema* est un générateur de mème « WE MAKE PORN » mais il peut faire bien plus.
+
+### Captures d'écran
+
+![Captures d'écran de WemaWema](https://github.com/YunoHost-Apps/wemawema_ynh/blob/master/doc/screenshots/WemaWema.png)
+
+## Liens utiles
+
++ Site web : [framagit.org/luc/wemawema](https://framagit.org/luc/wemawema)
++ Démonstration : [Démo](https://luc.frama.io/wemawema/)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/wemawema](https://github.com/YunoHost-Apps/wemawema_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/wemawema/issues](https://github.com/YunoHost-Apps/wemawema_ynh/issues)

--- a/pages/04.applications/10.docs/wemawema/app_wemawema.md
+++ b/pages/04.applications/10.docs/wemawema/app_wemawema.md
@@ -1,0 +1,27 @@
+---
+title: WemaWema
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_wemawema'
+---
+
+[![Installer WemaWema with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=wemawema) [![Integration level](https://dash.yunohost.org/integration/wemawema.svg)](https://dash.yunohost.org/appci/app/wemawema)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*WemaWema* is a "WE MAKE PORN" meme generator but it can do more.
+
+### Screenshots
+
+![Screenshots of WemaWema](https://github.com/YunoHost-Apps/wemawema_ynh/blob/master/doc/screenshots/WemaWema.png)
+
+## Useful links
+
++ Website: [framagit.org/luc/wemawema](https://framagit.org/luc/wemawema)
++ Demonstration: [Demo (fr)](https://luc.frama.io/wemawema/)
++ Application software repository: [github.com - YunoHost-Apps/wemawema](https://github.com/YunoHost-Apps/wemawema_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/wemawema/issues](https://github.com/YunoHost-Apps/wemawema_ynh/issues)

--- a/pages/04.applications/10.docs/wetty/app_wetty.fr.md
+++ b/pages/04.applications/10.docs/wetty/app_wetty.fr.md
@@ -1,0 +1,42 @@
+---
+title: Wetty
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_wetty'
+---
+
+[![Installer Wetty avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=wetty) [![Integration level](https://dash.yunohost.org/integration/wetty.svg)](https://dash.yunohost.org/appci/app/wetty)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*Wetty* est une application Terminal sur HTTP et HTTPS. WeTTy est une alternative à ajaxterm et anyterm mais bien meilleure qu'eux car WeTTy utilise xterm.js qui est une implémentation complète de l'émulation de terminal écrite entièrement en JavaScript. WeTTy utilise des websockets plutôt que Ajax et donc un meilleur temps de réponse.
+
+### Captures d'écran
+
+![Capture d'écran de Wetty](https://github.com/YunoHost-Apps/wetty_ynh/blob/master/doc/screenshots/terminal.png)
+
+### Avertissements / informations importantes
+
+#### Configuration
+
+Il y a peu de configuration dans Wetty :
+* La configuration de démarrage (port d'écoute, chemin d'URL, hôte SSH) est contenue dans le fichier de service systemd
+* La configuration de l'interface utilisateur se fait via l'interface graphique Web elle-même.
+
+* L'authentification LDAP et HTTP est-elle prise en charge ? **Non**
+  * Vous devez vous connecter manuellement.
+  * Vous pouvez spécifier l'utilisateur en accédent directement `https://<host>/wetty/ssh/<username>`
+
+* Vous pouvez spécifier à l'installation si Wetty devrait être accessible par des visiteurs non connectés sur YunoHost.
+
+* Vous ne pouvez pas vous authentifier par une clé SSH.
+
+## Liens utiles
+
++ Site web : [github.com/butlerx/wetty](https://github.com/butlerx/wetty)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/wetty](https://github.com/YunoHost-Apps/wetty_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/wetty/issues](https://github.com/YunoHost-Apps/wetty_ynh/issues)

--- a/pages/04.applications/10.docs/wetty/app_wetty.md
+++ b/pages/04.applications/10.docs/wetty/app_wetty.md
@@ -1,0 +1,42 @@
+---
+title: Wetty
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_wetty'
+---
+
+[![Installer Wetty with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=wetty) [![Integration level](https://dash.yunohost.org/integration/wetty.svg)](https://dash.yunohost.org/appci/app/wetty)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*Wetty* is a Terminal application over HTTP and HTTPS. WeTTy is an alternative to ajaxterm and anyterm but much better than them because WeTTy uses xterm.js which is a full fledged implementation of terminal emulation written entirely in JavaScript. WeTTy uses websockets rather then Ajax and hence better response time.
+
+### Screenshots
+
+![Screenshot of Wetty](https://github.com/YunoHost-Apps/wetty_ynh/blob/master/doc/screenshots/terminal.png)
+
+### Disclaimers / important information
+
+#### Configuration
+
+There is few configuration in Wetty:
+* Startup config (listen port, URL path, SSH host) is contained in the systemd service file
+* User interface configuration is done through the web GUI itself.
+
+* Is LDAP and HTTP authentication supported? **No**
+  * You need to manually log in.
+  * You can log in as a specific user using `https://<host>/wetty/ssh/<username>`
+
+* You can specify at install if Wetty should be visible by users not logged into YunoHost.
+
+* You can't use ssh key authentication.
+
+## Useful links
+
++ Website: [github.com/butlerx/wetty](https://github.com/butlerx/wetty)
++ Application software repository: [github.com - YunoHost-Apps/wetty](https://github.com/YunoHost-Apps/wetty_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/wetty/issues](https://github.com/YunoHost-Apps/wetty_ynh/issues)

--- a/pages/04.applications/10.docs/yellow/app_yellow.fr.md
+++ b/pages/04.applications/10.docs/yellow/app_yellow.fr.md
@@ -1,0 +1,27 @@
+---
+title: Yellow
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_yellow'
+---
+
+[![Installer Yellow avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=yellow) [![Integration level](https://dash.yunohost.org/integration/yellow.svg)](https://dash.yunohost.org/appci/app/yellow)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*Yellow* est un système de gestion de contenu (CMS) pour un site simple.
+
+## Captures d'écran
+
+![Capture d'écran de Yellow](https://github.com/YunoHost-Apps/yellow_ynh/blob/master/doc/screenshots/datenstrom-yellow-en.png)
+
+## Liens utiles
+
++ Site web : [datenstrom.se/yellow/](https://datenstrom.se/yellow/)
++ Démonstration : [Démo](https://datenstrom.se/yellow/demo/)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/yellow](https://github.com/YunoHost-Apps/yellow_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/yellow/issues](https://github.com/YunoHost-Apps/yellow_ynh/issues)

--- a/pages/04.applications/10.docs/yellow/app_yellow.md
+++ b/pages/04.applications/10.docs/yellow/app_yellow.md
@@ -1,0 +1,27 @@
+---
+title: Yellow
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_yellow'
+---
+
+[![Installer Yellow with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=yellow) [![Integration level](https://dash.yunohost.org/integration/yellow.svg)](https://dash.yunohost.org/appci/app/yellow)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*Yellow* is a content management system (CMS) for simple website.
+
+### Screenshots
+
+![Screenshot of Yellow](https://github.com/YunoHost-Apps/yellow_ynh/blob/master/doc/screenshots/datenstrom-yellow-en.png)
+
+## Useful links
+
++ Website: [datenstrom.se/yellow/](https://datenstrom.se/yellow/)
++ Demonstration: [Demo](https://datenstrom.se/yellow/demo/)
++ Application software repository: [github.com - YunoHost-Apps/yellow](https://github.com/YunoHost-Apps/yellow_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/yellow/issues](https://github.com/YunoHost-Apps/yellow_ynh/issues)

--- a/pages/04.applications/10.docs/yeswiki/app_yeswiki.fr.md
+++ b/pages/04.applications/10.docs/yeswiki/app_yeswiki.fr.md
@@ -1,0 +1,42 @@
+---
+title: YesWiki
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_yeswiki'
+---
+
+[![Installer YesWiki avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=yeswiki) [![Integration level](https://dash.yunohost.org/integration/yeswiki.svg)](https://dash.yunohost.org/appci/app/yeswiki)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*YesWiki* est un wiki conçu pour rester simple, très facile à installer, en français traduit en anglais, espagnol, catalan, flamand...
+
+Néanmoins, avec un YesWiki on peut fabriquer un site internet aux usages multiples :
+- Rassembler toutes les infos d'un projet ou d'un groupe (fonction de "gare centrale")
+- Cartographier des membres ou des lieux de façon participative
+- Partager des ressources, des listes, des agendas grâce à des bases de données coopératives puissantes
+- Faire communiquer des flux d'informations
+- Cultiver un bout de liberté...
+
+### Captures d'écran
+
+![Capture d'écran de YesWiki](https://github.com/YunoHost-Apps/yeswiki_ynh/blob/master/doc/screenshots/yeswiki_screenshots.png)
+
+### Avertissements / informations importantes
+
+##### Support multi-utilisateurs
+
+L'intégration au LDAP est la seule méthode supportée pour les nouvelles installations. Il est possible de la désactiver sur les anciennes installations en retirant l'extension loginldap. **Attention : Ne pas retirer l'extension sans connaitre d'identifiants administrateurs du wiki**
+
+Pour le moment l'authentification SSO n'est pas prise en charge. Il est nécessaire de se connecter sur le wiki.
+
+## Liens utiles
+
++ Site web : [yeswiki.net](https://yeswiki.net)
++ Démonstration : [Démo](https://ferme.yeswiki.net/?CreerSonWiki)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/yeswiki](https://github.com/YunoHost-Apps/yeswiki_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/yeswiki/issues](https://github.com/YunoHost-Apps/yeswiki_ynh/issues)

--- a/pages/04.applications/10.docs/yeswiki/app_yeswiki.md
+++ b/pages/04.applications/10.docs/yeswiki/app_yeswiki.md
@@ -1,0 +1,42 @@
+---
+title: YesWiki
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_yeswiki'
+---
+
+[![Installer YesWiki with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=yeswiki) [![Integration level](https://dash.yunohost.org/integration/yeswiki.svg)](https://dash.yunohost.org/appci/app/yeswiki)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*YesWiki* is a wiki designed to remain simple, very easy to install, in French translated into English, Spanish, Catalan, Flemish...
+
+However, with a YesWiki we can build a website with multiple uses:
+- Gather all the information of a project or a group (function of "central station")
+- Mapping members or places in a participatory way
+- Share resources, lists, calendars thanks to powerful cooperative databases
+- Communicate information flows
+- Cultivate a bit of freedom...
+
+### Screenshots
+
+![Screenshot of YesWiki](https://github.com/YunoHost-Apps/yeswiki_ynh/blob/master/doc/screenshots/yeswiki_screenshots.png)
+
+### Disclaimers / important information
+
+##### Multi-users support
+
+LDAP integration is supported and required on new installs. It is possible to disable it on older installs by removing the loginldap plugin. **Warning: only do it if you know credentials for a wiki admin account**
+
+At the moment SSO authentication is not supported. It is necessary to login on the wiki.
+
+## Useful links
+
++ Website: [yeswiki.net](https://yeswiki.net)
++ Demonstration: [Demo (fr)](https://ferme.yeswiki.net/?CreerSonWiki)
++ Application software repository: [github.com - YunoHost-Apps/yeswiki](https://github.com/YunoHost-Apps/yeswiki_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/yeswiki/issues](https://github.com/YunoHost-Apps/yeswiki_ynh/issues)

--- a/pages/04.applications/10.docs/zap/app_zap.fr.md
+++ b/pages/04.applications/10.docs/zap/app_zap.fr.md
@@ -1,0 +1,56 @@
+---
+title: Zap
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_zap'
+---
+
+[![Installer Zap avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=zap) [![Integration level](https://dash.yunohost.org/integration/zap.svg)](https://dash.yunohost.org/appci/app/zap)
+
+### Index
+
+- [Liens utiles](#liens-utiles)
+
+*Zap* est une alternative éthique au Fediverse qui fournit des fonctionnalités puissantes pour créer des sites web interconnectés avec une identité décentralisée, des communications et un cadre de permissions construit en utilisant la technologie commune des serveurs web.
+
+Compatible avec **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **Funkwhale**, **Peertube**, **Plume**, **WriteFreely** et beaucoup, beaucoup d'autres.
+
+### Caractéristiques uniques de ZAP
+
+- **Groupes** : publics, privés, et modérés.
+- **Événements** : Calendrier et présence ; notifications automatiques d'anniversaire pour les amis utilisant cette fonctionnalité.
+- **Cloud**storage : Stockage de fichiers en réseau intégré avec accès aux réseaux sociaux.
+- Éditeur** : Supporte à la fois markdown et bbcode. Utilisez l'un ou l'autre, ou les deux, si vous le souhaitez.
+- **Partage** : Glissez-déposez un certain nombre de choses différentes comme des fichiers, des photos, des pages Web, des cartes, des numéros de téléphone pour les partager.
+- Listes** : Parfois appelé cercles ou aspects, cela vous permet de définir vos propres groupes d'amis liés et de communiquer avec eux comme un groupe privé.
+- **Extension** : Modifiez ou mettez à niveau les fonctionnalités de votre logiciel comme vous le souhaitez en installant des fonctions supplémentaires à partir de modules complémentaires et de la collection d'applications gratuites.
+
+### Avertissements / informations importantes
+
+### Installation
+
+Avant de procéder à l'installation, lisez les [Instructions d'installation de Zap](https://codeberg.org/zot/zap/src/branch/release/install/INSTALL.txt) pour obtenir des informations importantes sur les points suivants
+
+#### Enregistrer un nouveau domaine et l'ajouter à YunoHost
+
+- Zap nécessite un domaine dédié, alors obtenez-en un et ajoutez-le en utilisant le panneau d'administration de YunoHost. **Domaines -> Ajouter un domaine**. Comme Zap utilise le domaine complet et est installé à la racine, vous pouvez créer un sous-domaine tel que `zap.domain.tld`. N'oubliez pas de mettre à jour vos DNS si vous les gérez manuellement.
+
+### Droits d'utilisateur de l'administrateur LDAP, journaux et échecs de mise à jour de la base de données
+
+- **Pour les droits d'administration** : Une fois l'installation terminée, vous devrez vous rendre sur la page de votre nouveau hub et vous connecter avec le **nom d'utilisateur du compte admin** qui a été saisi au moment de l'installation. Vous devriez alors être en mesure de créer votre premier canal et avoir les **droits d'administrateur** pour le hub.
+
+- **Pour les utilisateurs normaux de YunoHost :** Les utilisateurs normaux de LDAP peuvent se connecter via l'authentification Ldap et créer leurs canaux.
+
+- Si l'administrateur ne peut pas accéder aux paramètres d'administration à `https://zap.example.com/admin` ou si vous voulez accorder des droits d'administration à un autre utilisateur sur le hub, alors vous devez **ajouter manuellement 4096** aux **rôles_comptes** sous **comptes** pour cet utilisateur dans la **base de données via phpMYAdmin**.
+
+- **Pour les logs:** Allez dans **admin->logs** et entrez le nom du fichier **php.log**.
+
+- Échec de la base de données après la mise à jour:** Parfois, la mise à jour de la base de données échoue après la mise à jour de la version. Vous pouvez aller sur le hub, par exemple `https://zap.example.com/admin/dbsync/` et vérifier le nombre de mises à jour qui ont échoué. Ces mises à jour devront être exécutées manuellement par **phpMYAdmin**.
+
+## Liens utiles
+
++ Site web : [codeberg.org/zot/zap](https://codeberg.org/zot/zap)
++ Dépôt logiciel de l'application : [github.com - YunoHost-Apps/zap](https://github.com/YunoHost-Apps/zap_ynh)
++ Remonter un bug ou une amélioration en créant un ticket (issue) : [github.com - YunoHost-Apps/zap/issues](https://github.com/YunoHost-Apps/zap_ynh/issues)

--- a/pages/04.applications/10.docs/zap/app_zap.md
+++ b/pages/04.applications/10.docs/zap/app_zap.md
@@ -1,0 +1,56 @@
+---
+title: Zap
+template: docs
+taxonomy:
+    category: docs, apps
+routes:
+  default: '/app_zap'
+---
+
+[![Installer Zap with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=zap) [![Integration level](https://dash.yunohost.org/integration/zap.svg)](https://dash.yunohost.org/appci/app/zap)
+
+### Index
+
+- [Useful links](#useful-links)
+
+*Zap* is an an ethical alternative to Fediverse that provides powerful features for creating interconnected websites featuring a decentralized identity, communications, and permissions framework built using common webserver technology.
+
+Compatible with **Mastodon**, **Pleroma**, **Pixelfed**, **Friendica**, **Hubzilla**, **Funkwhale**, **Peertube**, **Plume**, **WriteFreely** and many, many more.
+
+### Unique Features of ZAP
+
+- **Groups** : public, private, and moderated.
+- **Events** : Calendar and attendance; automatic birthday notifications for friends using this feature.
+- **Cloud**storage : Built-in network file storage integrated with social networking access.
+- **Editor** : Supports both markdown and bbcode. Use either or both - if you want.
+- **Share**: Drag-and-drop a number of different things such as files, photos, webpages, maps, phone numbers to share- them.
+- **Lists**: Sometimes referred to as circles or aspects, this lets you define your own groups of related friends and- communicate with them as a private group.
+- **Extend** : Change or upgrade your software functionality as desired by installing additional features from addons and- the free app collection.
+
+### Disclaimers / important information
+
+### Installation
+
+Before installing, read the [Zap installation instructions](https://codeberg.org/zot/zap/src/branch/release/install/INSTALL.txt) for important information about:
+
+#### Register a new domain and add it to YunoHost
+
+- Zap requires a dedicated domain, so obtain one and add it using the YunoHost admin panel. **Domains -> Add domain**. As Zap uses the full domain and is installed on the root, you can create a subdomain such as `zap.domain.tld`. Don't forget to update your DNS if you manage them manually.
+
+### LDAP Admin user rights, logs and failed database updates
+
+- **For admin rights**: When installation is complete, you will need to visit your new hub's page and login with the **admin account username** which was entered at the time of installation process. You should then be able to create your first channel and have the **admin rights** for the hub.
+
+- **For normal YunoHost users :** Normal LDAP users can login through Ldap authentication and create there channels.
+
+- **Failing to get admin rights :** If the admin cannot access the admin settings at `https://zap.example.com/admin` or you want to grant admin rights to any other user(s) on the hub, then you have to **manually add 4096** to the **account_roles** under **accounts** for that user in the **database through phpMYAdmin**.
+
+- **For logs:** Go to **admin->logs** and enter the file name **php.log**.
+
+- **Failed Database after Upgrade:** Some times databse upgrade fails after version upgrade. You can go to hub eg. `https://zap.example.com/admin/dbsync/` and check the numbers of failled update. These updates will have to be ran manually by **phpMYAdmin**.
+
+## Useful links
+
++ Website: [codeberg.org/zot/zap](https://codeberg.org/zot/zap)
++ Application software repository: [github.com - YunoHost-Apps/zap](https://github.com/YunoHost-Apps/zap_ynh)
++ Fix a bug or an improvement by creating a ticket (issue): [github.com - YunoHost-Apps/zap/issues](https://github.com/YunoHost-Apps/zap_ynh/issues)


### PR DESCRIPTION
Create doc
app_teampass
app_thelounge
app_tiddlywiki
app_trilium
app_tyto
app_vikunja
app_wemawema
app_wetty
app_yellow
app_yeswiki
app_zap
Once this PR has been validated, unless one has been forgotten, all missing documentation for applications with a star will have been initialised apart from PyInventory.