### PR TITLE
Ignore yunohost-api error when not running

### DIFF
--- a/pages/02.administer/45.tutorials/60.security/security.md
+++ b/pages/02.administer/45.tutorials/60.security/security.md
@@ -104,7 +104,7 @@ sudo systemctl disable yunohost-api
 sudo systemctl stop yunohost-api
 ```
 
-As yunohost-api is now disabled and not running, Diagnosis will report an error and cannot be ignored from the API.
+As `yunohost-api` is now disabled and not running, Diagnosis will report an error and cannot be ignored from the API.
 If you want to ignore this error, you can configure YunoHost from the CLI.
 
 ```bash

--- a/pages/02.administer/45.tutorials/60.security/security.md
+++ b/pages/02.administer/45.tutorials/60.security/security.md
@@ -105,7 +105,7 @@ sudo systemctl stop yunohost-api
 ```
 
 As yunohost-api is now disabled and not running, Diagnosis will report an error and cannot be ignored from the API.
-If you want to ignore this error, you can configure yunohost from the CLI.
+If you want to ignore this error, you can configure YunoHost from the CLI.
 
 ```bash
 sudo yunohost diagnosis ignore --filter services service=yunohost-api

--- a/pages/02.administer/45.tutorials/60.security/security.md
+++ b/pages/02.administer/45.tutorials/60.security/security.md
@@ -94,7 +94,7 @@ sudo yunohost settings set security.ssh.compatibility -v modern
 
 YunoHost administration is accessible through an **HTTP API**, served on the 6787 port by default (only on `localhost`).
 It can be used to administer a lot of things on your server, so malicious actors can also use it to damage your server.
-The best thing to do, if you know how to use the [command-line interface](/commandline), is to deactivate the `yunohost-api` service.
+The best thing to do, if you know how to use the [command-line interface (CLI)](/commandline), is to deactivate the `yunohost-api` service.
 
 ! This will completely disable both YunoHost's API and the web administration panel that relies on it.
 ! Proceed only if you are comfortable with the command line interface.
@@ -102,4 +102,11 @@ The best thing to do, if you know how to use the [command-line interface](/comma
 ```bash
 sudo systemctl disable yunohost-api
 sudo systemctl stop yunohost-api
+```
+
+As yunohost-api is now disabled and not running, Diagnosis will report an error and cannot be ignored from the API.
+If you want to ignore this error, you can configure yunohost from the CLI.
+
+```bash
+sudo yunohost diagnosis ignore --filter services service=yunohost-api
 ```


### PR DESCRIPTION
Add instruction to ignore the error about yunohost-api not running when it is intentionally stopped and disabled.