### PR TITLE
Add Teleport

### DIFF
--- a/pages/04.applications/99.wishlist/apps_wishlist.md
+++ b/pages/04.applications/99.wishlist/apps_wishlist.md
@@ -307,6 +307,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [Technitium DNS](https://technitium.com/dns/) |  | [Upstream](https://github.com/TechnitiumSoftware/DnsServer) |  |
 | [Teddy.io](https://teedy.io/) | Document manager | [Upstream](https://github.com/sismics/docs) |  |
 | telegram_chatbot | Telegram chatbot - mini chatbot for Telegram |  | [Package Draft](https://github.com/YunoHost-Apps/telegram_chatbot_ynh) |
+| [Teleport](https://goteleport.com/) | Teleport is an identity-aware, multi-protocol access proxy which understands SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire protocols. | [Upstream](https://github.com/gravitational/teleport) |  |
 | TellForm |  | [Upstream](https://github.com/tellform/tellform) |  |
 | [tes3mp](https://tes3mp.com/) |  |  | [Package Draft](https://github.com/YunoHost-Apps/tes3mp_ynh) |
 | [Theia-IDE](https://theia-ide.org/) | VS Code-like cloud IDE |[Upstream](https://hub.docker.com/r/theiaide/theia-full)| |

--- a/pages/04.applications/99.wishlist/apps_wishlist.md
+++ b/pages/04.applications/99.wishlist/apps_wishlist.md
@@ -307,7 +307,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [Technitium DNS](https://technitium.com/dns/) |  | [Upstream](https://github.com/TechnitiumSoftware/DnsServer) |  |
 | [Teddy.io](https://teedy.io/) | Document manager | [Upstream](https://github.com/sismics/docs) |  |
 | telegram_chatbot | Telegram chatbot - mini chatbot for Telegram |  | [Package Draft](https://github.com/YunoHost-Apps/telegram_chatbot_ynh) |
-| [Teleport](https://goteleport.com/) | Teleport is an identity-aware, multi-protocol access proxy which understands SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire protocols. | [Upstream](https://github.com/gravitational/teleport) |  |
+| [Teleport](https://goteleport.com/) | Multi-protocol access proxy which understands SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire protocols. | [Upstream](https://github.com/gravitational/teleport) |  |
 | TellForm |  | [Upstream](https://github.com/tellform/tellform) |  |
 | [tes3mp](https://tes3mp.com/) |  |  | [Package Draft](https://github.com/YunoHost-Apps/tes3mp_ynh) |
 | [Theia-IDE](https://theia-ide.org/) | VS Code-like cloud IDE |[Upstream](https://hub.docker.com/r/theiaide/theia-full)| |


### PR DESCRIPTION
Added request for Teleport.
it is an identity-aware, multi-protocol access proxy which understands SSH, HTTPS, RDP, Kubernetes API, MySQL, MongoDB and PostgreSQL wire protocols.

```
Installation demonstration using docker:
https://www.youtube.com/watch?v=nk1jfIAL5qE
```