### PR TITLE
restauration complète durant la post-intall

### DIFF
--- a/pages/02.administer/15.admin_guide/50.backups/backup.fr.md
+++ b/pages/02.administer/15.admin_guide/50.backups/backup.fr.md
@@ -123,6 +123,14 @@ ls -lh /home/yunohost.backup/archives/ARCHIVE.tar
 ### Restaurer
 
 !!! SPOILER: Plus votre volume de données et le nombre d'applications sont important, plus votre restauration sera complexe.
+
+#### Restauration complète durant la post-installation
+
+copiez l'archive contenant la sauvegarde à restaurer (<archivename>.tar avec <archivename>.info.json associé) dans `/home/yunohost.backup/arhives/`
+A partir de la ligne de commande, vous pouvez exécuter `yunohost backup restore <archivename>` (sans son extension .tar) (pour mémoire, pour se logger en ligne de commande avant la fin de la configuration login:`root` motdepasse:`yunohost`)
+    
+Il ne vous reste plus qu'à patienter jusqu'à la fin de la restauration
+    
 #### Cas simple : peu de données, archive déjà présente
 
 [ui-tabs position="top-left" active="0" theme="lite"]


### PR DESCRIPTION
suite au passage de mon Yuno de 32 bits en 64 bits, j'ai rencontré quelques difficultés et beaucoup de questions. Pour un néophite, la doc ne me paraissait pas très clair sur ce sujet.
- ajout d'un paragraphe concernant la restauration complète d'un serveur durant la post-installation.
- la procedure serait placée après  "restaurer" ligne 123 
- pourriez-vous faire pointer "https://yunohost.org/fr/backup#restoring-during-the-postinstall"  vers ce paragraphe (lien venant de cette page "https://yunohost.org/fr/install/hardware:rpi2plus" sous le paragraphe "Lancer la configuration intiale"