### PR TITLE
Add FreeIPA M$ Active-Directory Domain-Controller

### DIFF
--- a/pages/04.applications/99.wishlist/apps_wishlist.md
+++ b/pages/04.applications/99.wishlist/apps_wishlist.md
@@ -109,6 +109,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | Framaestro | Online service aggregator | [Upstream](https://framagit.org/framasoft/framaestro) | [Package Draft](https://github.com/YunoHost-Apps/framaestro_ynh) |
 | Framaestro_hub | Online service aggregator hub | [Upstream](https://github.com/mozilla/togetherjs.git) | [Package Draft](https://github.com/YunoHost-Apps/framaestro_hub_ynh) |
 | [freeboard](https://freeboard.io/) | A real-time dashboard builder for IOT |  | [Package Draft](https://github.com/YunoHost-Apps/freeboard_ynh) |
+| [FreeIPA](https://www.freeipa.org/) | A M$ Active-Directory Domain-Controller implementation by RedHat with web-interface | [Upstream](https://pagure.io/freeipa) | Debian11 packages via "bullseye-backports" repository |
 | [freepbx](https://freepbx.org) | VOIP |  | [Package Draft](https://github.com/YunoHost-Apps/freepbx_ynh) |
 | [Freescout](https://freescout.net/) |  Helpdesk & Shared Mailbox | [Upstream](https://github.com/freescout-helpdesk/freescout) |  |
 | [ftssolr](https://wiki.dovecot.org/Plugins/FTS/Solr) | Full-text search via IMAP through a Solr indexing server |  | [Package Draft](https://github.com/YunoHost-Apps/ftssolr_ynh) |


### PR DESCRIPTION
FreeIPA is M$ Active-Directory Domain-Controller implementation by RedHat with a web-interface.