### PR TITLE
Elk fediverse web client

### DIFF
--- a/pages/04.applications/99.wishlist/apps_wishlist.md
+++ b/pages/04.applications/99.wishlist/apps_wishlist.md
@@ -81,6 +81,7 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | DrakonHub | Online editor for Drakon diagrams | [Upstream](https://github.com/stepan-mitkin/drakonhub) | |
 | [Drawpile](https://drawpile.net) | Collaborative drawing program that allows multiple users to sketch on the same canvas simultaneously | [Upstream](https://github.com/drawpile/Drawpile) | |
 | [Element Call](https://element.io/blog/element-call-beta-2-encryption-spatial-audio-walkie-talkie-mode-and-more/) | Showcase for full mesh video chat powered by Matrix | [Upstream](https://github.com/vector-im/element-call) |  |
+| [Elk](https://elk.zone) | A nimble Mastodon web client. It also works with other Fediverse servers like Pleroma or GotoSocial | [upstream](https://github.com/elk-zone/elk) |  |
 | Endlessh | SSH Tarpit | [upstream](https://github.com/skeeto/endlessh) |  |
 | [erine.email](https://erine.email/) |  | [Upstream](https://gitlab.com/mdavranche/erine.email) |  |
 | [ERPnext](https://erpnext.com/) |  | [Upstream](https://github.com/frappe/erpnext) |  |


### PR DESCRIPTION
adding fediverse web client Elk, it also can be used with Mastodon, Pleroma, GotoSocial, etc. servers.