### PR TITLE
Apps - Noalyss - Fixed broken link and removed misleading information

### DIFF
--- a/pages/04.applications/10.docs/noalyss/app_noalyss.fr.md
+++ b/pages/04.applications/10.docs/noalyss/app_noalyss.fr.md
@@ -9,12 +9,12 @@ routes:
 
 Logiciel de comptabilité open source développé en PHP.
 
-Toute les infos sur ce logiciel sont disponible sur le [site du projet](http://www.noalyss.eu)
+Toute les infos sur ce logiciel sont disponible sur le [site du projet](http://www.noalyss.eu).
 
-Pour apprendre à l'utiliser je vous invite à lire le [wiki du projet](http://www.noalyss.eu/?page_id=46&lang=fr_FR)
+Pour apprendre à l'utiliser je vous invite à lire la [documentation utilisateur du projet](https://www.noalyss.eu/?page_id=1031).
 
-Le github du module YunoHost est [ici](https://github.com/YunoHost-Apps/noalyss_ynh)
+Le github du module YunoHost est [ici](https://github.com/YunoHost-Apps/noalyss_ynh).
 
-Vous pouvez essayer le projet [ici](http://demo.noalyss.eu/index.php) avec les identifiants : demo /demo
+Vous pouvez essayer le projet [ici](http://demo.noalyss.eu/index.php) avec les identifiants : demo / demo
 
-Enfin pour ne pas galérer comme moi. Les identifiants et mot de passe administrateur lors de la première connexion sont : phpcompta / phpcompta
+Les identifiants et mot de passe administrateur lors de la première connexion sont ceux définis à l'installation (également envoyés sur l'adresse email de l'administrateur sur votre domaine YNH).

--- a/pages/04.applications/10.docs/noalyss/app_noalyss.md
+++ b/pages/04.applications/10.docs/noalyss/app_noalyss.md
@@ -13,7 +13,7 @@ All the information on this software is available on the [project website](http:
 
 To learn how to use it I invite you to read the [user documentation of the project](https://www.noalyss.eu/?page_id=1031).
 
-The github of the YunoHost module is [here](https://github.com/YunoHost-Apps/noalyss_ynh_ynh).
+The GitHub of the YunoHost module is [here](https://github.com/YunoHost-Apps/noalyss_ynh_ynh).
 
 You can try the project [here](http://demo.noalyss.eu/index.php) with the identifiers: demo / demo
 

--- a/pages/04.applications/10.docs/noalyss/app_noalyss.md
+++ b/pages/04.applications/10.docs/noalyss/app_noalyss.md
@@ -9,12 +9,12 @@ routes:
 
 Open source accounting software developed in PHP.
 
-All the information on this software is available on the [project website](http://www.noalyss.eu)
+All the information on this software is available on the [project website](http://www.noalyss.eu).
 
-To learn how to use it I invite you to read the [project wiki](http://www.noalyss.eu/?page_id=46&lang=fr_FR_id=46&lang=en_EN)
+To learn how to use it I invite you to read the [user documentation of the project](https://www.noalyss.eu/?page_id=1031).
 
-The github of the YunoHost module is [here](https://github.com/YunoHost-Apps/noalyss_ynh_ynh)
+The github of the YunoHost module is [here](https://github.com/YunoHost-Apps/noalyss_ynh_ynh).
 
-You can try the project [here](http://demo.noalyss.eu/index.php) with the identifiers: demo /demo
+You can try the project [here](http://demo.noalyss.eu/index.php) with the identifiers: demo / demo
 
-I mean, not to have to struggle like me. The administrator IDs and passwords for the first login are: phpcompta / phpcompta
+The administrator IDs and passwords for the first login are those defined during the package installation (sent as a memo to the email address of this app's administrator at your YNH domain). 


### PR DESCRIPTION
In Noalyss app docs:
- Fixed link to user documentation leading to a 404 page
- Removed misleading login information which is likely to be related to an old version of the package 

You might find it difficult to check the relevancy of the second point since current YNH package for this app is broken. This pull request is meant to be associated to [that other pull request](https://github.com/YunoHost-Apps/noalyss_ynh/pull/39) which aims at fixing the current package.