### PR TITLE
Fix broken links

### DIFF
--- a/pages/06.contribute/10.packaging_apps/60.advanced/60.advanced_packagers/advanced_packagers.md
+++ b/pages/06.contribute/10.packaging_apps/60.advanced/60.advanced_packagers/advanced_packagers.md
@@ -8,7 +8,6 @@ routes:
 ---
 
 Here comes the time:
-- you know all the [YEPs](/packaging_apps_guidelines)
 - you masterise [apps packaging](/packaging_apps), [package_check](https://github.com/YunoHost/package_check), [example_ynh](https://github.com/YunoHost/example_ynh) and [experimental helpers](https://github.com/YunoHost-Apps/Experimental_helpers)
 - you have integrated the [YunoHost Apps Group](https://yunohost.org/#/project_organization)
 - you know what means `¯\_(ツ)_/¯`

--- a/pages/06.contribute/10.packaging_apps/80.resources/03.git/packaging_apps_git.fr.md
+++ b/pages/06.contribute/10.packaging_apps/80.resources/03.git/packaging_apps_git.fr.md
@@ -80,7 +80,7 @@ Lors de la création d'une pull request à partir d'un fork, pour faciliter le t
 
 #### Organisation YunoHost-Apps
 
-Conformément à la [YEP 1.7](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines.md#yep-17), votre application doit être intégrée à l'organisation YunoHost-Apps, mais si vous n'avez jamais contribué à une application auparavant ou si vous n'avez jamais eu d'application dans cette organisation, vous n'en aurez peut-être pas l'autorisation.
+Conformément au [guide de création d'applications dans YunoHost](/packaging_apps_intro), votre application doit être intégrée à l'organisation YunoHost-Apps, mais si vous n'avez jamais contribué à une application auparavant ou si vous n'avez jamais eu d'application dans cette organisation, vous n'en aurez peut-être pas l'autorisation.
 
 Tout d'abord, vous devez avoir la permission d'écrire dans l'organisation, pour ce faire, demandez au groupe Apps sur le salon XMPP Apps.
 

--- a/pages/06.contribute/10.packaging_apps/80.resources/03.git/packaging_apps_git.md
+++ b/pages/06.contribute/10.packaging_apps/80.resources/03.git/packaging_apps_git.md
@@ -80,7 +80,7 @@ When creating a pull request from a fork, to ease the work of the reviewers, **d
 
 #### YunoHost-Apps organization
 
-Following the [YEP 1.7](https://github.com/YunoHost/doc/blob/master/packaging_apps_guidelines.md#yep-17), your app has to be into the YunoHost-Apps organization, but if you have never contributed to an app before or never had any app into this organization you may not have the permission.
+Following the [guide for packaging application within YunoHost](/packaging_apps_intro), your app has to be into the YunoHost-Apps organization, but if you have never contributed to an app before or never had any app into this organization you may not have the permission.
 
 First, you need the permission to write into the organization, to do so, ask to the Apps group on the Apps XMPP room.
 


### PR DESCRIPTION
 Removing a few broken links in the doc pointing to `packaging_apps_guidelines.md` which has been removed in the last big refactor of the contributing doc.

I replaced the broken link with a link to `packaging_apps_intro.md`.