### PR TITLE
Removing SearXNG from apps wishlist

### DIFF
--- a/pages/04.applications/99.wishlist/apps_wishlist.md
+++ b/pages/04.applications/99.wishlist/apps_wishlist.md
@@ -274,7 +274,6 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [Screego](https://screego.net/) | Screen sharing webrtc | [Upstream](https://github.com/screego/server) |  |
 | [Scribe](https://scribe.rip/) | An alternative frontend to Medium | [Upstream](https://git.sr.ht/~edwardloveall/scribe) |  |
 | [Scuttlebutt Pub](https://www.scuttlebutt.nz/contributing) |  |  |  |
-| [SearXNG](https://searxng.github.io/searxng/) | Fork of SearX, a privacy-respecting metasearch engine | [Upstream](https://github.com/searxng/searxng) |  |
 | [seenthis](https://www.seenthis.net/) | Short-blogging destiné à la veille d’actualité |  | [Package Draft](https://github.com/magikcypress/seenthis_ynh) |
 | [Semantic MediaWiki](https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki) | lets you store and query data with­in the [MediaWiki](https://en.wikipedia.org/wiki/MediaWiki)'s pages | [Upstream](https://github.com/SemanticMediaWiki/SemanticMediaWiki) |  |
 | [shadowsocks](https://shadowsocks.org) | A SOCKS5 proxy to protect your Internet traffic |  | [Package Draft](https://github.com/YunoHost-Apps/shadowsocks_ynh) |


### PR DESCRIPTION
Removing SearXNG from apps wishlist as it is now packaged : https://github.com/YunoHost-Apps/searxng_ynh