### PR TITLE
Miscelaneous changes

### DIFF
--- a/pages/06.contribute/10.packaging_apps/10.manifest/docs.md
+++ b/pages/06.contribute/10.packaging_apps/10.manifest/docs.md
@@ -12,6 +12,7 @@ The app's `manifest.toml` can be seen as the ID card of the app. It declares var
 
 In this page, the data are described according to a somewhat dummy app called `helloworld`
 
+!!! If you want to convert an application from the packaging v1 to v2 format, [please see here](/packaging_v2)!
 
 ## General information
 

--- a/pages/06.contribute/10.packaging_apps/10.manifest/docs.md
+++ b/pages/06.contribute/10.packaging_apps/10.manifest/docs.md
@@ -160,4 +160,6 @@ In this example:
 - `permissions`: an SSOwat `$app.main` permission will be initialized such that the SSO allows access to the app's endpoint according to the chosen `init_main_permission` question. The `main.url = "/"` is here to tell that the main endpoint is the "root" of the app, that is `https://domain.tld/helloworld/` if the app is installed with `domain=domain.tld` and `path=/helloworld`
 - `apt`: the packages `nyancat`, `lolcat`, `sl` will be installed with `apt`. These are just dummy apt dependencies to illustrate the syntax.
 
-The full documentation on resources is available [here](/packaging_apps_resources)
+### List of app resources
+
+The full documentation on resources is available [here](/packaging_apps_resources).

--- a/pages/06.contribute/10.packaging_apps/10.manifest/docs.md
+++ b/pages/06.contribute/10.packaging_apps/10.manifest/docs.md
@@ -1,10 +1,11 @@
 ---
-title: Writing app manifest
+title: 'Writing the app manifest'
 template: docs
 taxonomy:
-    category: docs
+    category:
+        - docs
 routes:
-  default: '/packaging_manifest'
+    default: /packaging_manifest
 ---
 
 The app's `manifest.toml` can be seen as the ID card of the app. It declares various basic metadata such as the id, name, description of the app, its version, install questions to be asked to the admin prior to installation, etc.
@@ -16,31 +17,21 @@ In this page, the data are described according to a somewhat dummy app called `h
 
 ```toml
 packaging_format = 2
-```
-
-- `packaging_format` (`int`) is the packaging version format used to package this app. Newly packaged apps are strongly encouraged to use the new "v2" format (starting with YunoHost 11.1) while older apps may still be in "v1" format.
-
-```toml
 id = "helloworld"
 name = "Hello World"
 description.en = "A dummy basic app to illustrate YunoHost's app packaging."
 description.fr = "Une app simple et bidon pour illustrer comme le packaging d'app de YunoHost fonctionne"
-```
 
-- `id` (`str`) is expected to be lower-case alphanumeric (and possibly `-`). This is what will be used for instance in the syntax `yunohost app install <app_id>`. This will also be the name of various folder or conf files such as `/etc/yunohost/apps/<app_id>` or `/etc/nginx/conf.d/<domain>.d/<app_id>.conf` (if applicable), and a dedicated system user.
-- `name` (`str`) is the display name of the app, shown for example in the webadmin UI or user portal. It is limited to 22 chars <small>(though not sure why this number?)</small>.
-- `description` (`dict` of `lang code`->`str`) contains *short*, *concise* descriptions of the app in different languages (at least `en`). It is limited to 150 chars. It will be displayed on the app catalog and should allow people to understand what this app is about at a glance. A more extensive description of the app can be provided in `doc/DESCRIPTION.md`.
-
-```toml
 version = "0.1~ynh1"
-```
 
-- `version` (`str`) is composed of the *upstream* version of the app shipped, and an `~ynhX` suffix. Changing this version is what effectively triggers an available upgrade for YunoHost instances which installed this package (hence no upgrade will be displayed as available if you forget to change it). The point of the `~ynhX` suffix is to have a way to increment the version when commiting changes unrelated to the upstream but still trigger an upgrade.
-
-```toml
 maintainers = ["alexAubin"]
 ```
 
+- `packaging_format` (`int`) is the packaging version format used to package this app. Newly packaged apps are strongly encouraged to use the new "v2" format (starting with YunoHost 11.1) while older apps may still be in "v1" format.
+- `id` (`str`) is expected to be lower-case alphanumeric (and possibly `-`). This is what will be used for instance in the syntax `yunohost app install <app_id>`. This will also be the name of various folder or conf files such as `/etc/yunohost/apps/<app_id>` or `/etc/nginx/conf.d/<domain>.d/<app_id>.conf` (if applicable), and a dedicated system user.
+- `name` (`str`) is the display name of the app, shown for example in the webadmin UI or user portal. It is limited to 22 chars <small>(though not sure why this number?)</small>.
+- `description` (`dict` of `lang code`->`str`) contains *short*, *concise* descriptions of the app in different languages (at least `en`). It is limited to 150 chars. It will be displayed on the app catalog and should allow people to understand what this app is about at a glance. A more extensive description of the app can be provided in `doc/DESCRIPTION.md`.
+- `version` (`str`) is composed of the *upstream* version of the app shipped, and an `~ynhX` suffix. Changing this version is what effectively triggers an available upgrade for YunoHost instances which installed this package (hence no upgrade will be displayed as available if you forget to change it). The point of the `~ynhX` suffix is to have a way to increment the version when commiting changes unrelated to the upstream but still trigger an upgrade.
 - `maintainers` (`list` or `str`) may allow to declare which person should be the referring person for this package (though packages are often maintained collectively and not really used in practice). This should contain a list of easily identifiable persons (eg your Github or Matrix username)
 
 ## Upstream section

--- a/pages/06.contribute/10.packaging_apps/60.advanced/70.notes_about_new_packaging_v2/docs.md
+++ b/pages/06.contribute/10.packaging_apps/60.advanced/70.notes_about_new_packaging_v2/docs.md
@@ -1,12 +1,12 @@
 ---
-title: Packaging v2
+title: 'Packaging v2'
 template: docs
 taxonomy:
-    category: docs
+    category:
+        - docs
 routes:
-  default: '/packaging_v2'
+    default: /packaging_v2
 ---
-
 
 Packaging v2 is a major improvement for the packaging introduced in YunoHost 11.1
 
@@ -23,7 +23,7 @@ However, this "v2" is not the end of the story and should be seen as an intermed
 
 ### Adapting a v1 app to v2
 
-A script is available in https://github.com/YunoHost/apps/tree/master/tools/packaging_v2 and will attempt to convert what it can from the v1 format to the v2 format, in particular:
+A script is available in <https://github.com/YunoHost/apps/tree/master/tools/packaging_v2> and will attempt to convert what it can from the v1 format to the v2 format, in particular:
 - initializing a `manifest.toml` and prefilling it with info scrapped from the various scripts
 - comment out now-unecessary lines in the various scripts
 

--- a/pages/06.contribute/10.packaging_apps/packaging_apps_intro.fr.md
+++ b/pages/06.contribute/10.packaging_apps/packaging_apps_intro.fr.md
@@ -60,9 +60,9 @@ Cependant, [**un futur format v3** est encore à venir] (https://github.com/Yuno
 ## 4. Aperçu général de la structure d'une application YunoHost
 
 Une application YunoHost est construite dans un dépôt Git. Nous vous encourageons à jeter un coup d'oeil à ces dépôts de code pour vous familiariser avec les structures des dépôts d'applications :
-- l'application [`helloworld_ynh`](https://github.com/YunoHost-Apps/helloworld_ynh) 
-- l'application [`example_ynh`](https://github.com/YunoHost/example_ynh) which illustrates all common features and recommended formatting
-- votre application "réelle" préférée dans la liste des dépots [YunoHost-Apps].(https://github.com/orgs/YunoHost-Apps/repositories))
+- [l'application `helloworld_ynh`](https://github.com/YunoHost-Apps/helloworld_ynh) 
+- [l'application `example_ynh`](https://github.com/YunoHost/example_ynh) qui contient toutes les fonctionnalités générales et le formattage recommandé
+- votre application "réelle" préférée dans la liste des dépots [YunoHost-Apps](https://github.com/orgs/YunoHost-Apps/repositories)
 
 Parmi les fichiers contenus dans un paquet, les plus importants sont les suivants :
 

--- a/pages/06.contribute/10.packaging_apps/packaging_apps_intro.md
+++ b/pages/06.contribute/10.packaging_apps/packaging_apps_intro.md
@@ -60,9 +60,9 @@ However, [**a future v3 format** has yet to come](https://github.com/YunoHost/is
 ## 4. General overview of a YunoHost app structure
 
 A YunoHost app consists in a Git repository. We encourage you to have a look at those code repository to get familiar witch app repository structures:
-- the [`helloworld_ynh`](https://github.com/YunoHost-Apps/helloworld_ynh) app 
-- the [`example_ynh`](https://github.com/YunoHost/example_ynh) app which illustrates all common features and recommended formatting
-- your favourite "real-life" app in the [YunoHost-Apps organization](https://github.com/orgs/YunoHost-Apps/repositories))
+- [the `helloworld_ynh` app](https://github.com/YunoHost-Apps/helloworld_ynh)
+- [the `example_ynh` app](https://github.com/YunoHost/example_ynh) which illustrates all common features and recommended formatting
+- your favourite "real-life" app in the [YunoHost-Apps organization](https://github.com/orgs/YunoHost-Apps/repositories)
 
 Among the file contained in a package, the most important ones are: 
 


### PR DESCRIPTION
* "Writing app manifest": rename page and reorder the first paragraph (more consistent with the rest of the article)
* Add a disclaimer about manifest v1 -> v2 conversion in the manifest writing doc page
* Fix links
* Add a subsection at the end of packaging_manifest
* Fix links visibility in packaging_apps: they aren't really visible now.