### PR TITLE
Remove fittrackee from wishlist

### DIFF
--- a/pages/04.applications/99.wishlist/apps_wishlist.md
+++ b/pages/04.applications/99.wishlist/apps_wishlist.md
@@ -98,7 +98,6 @@ You can [contribute to this list by adding something you'd like to be packaged](
 | [Firefly-III Data Importer](https://docs.firefly-iii.org/data-importer) | Import data from banks to Firefly | [Upstream](https://github.com/firefly-iii/data-importer) | [Draft Package](https://github.com/marcoil/firefly-iii-di_ynh) |
 | [Filestash](https://www.filestash.app/) |  | [Upstream](https://github.com/mickael-kerjean/filestash) |  |
 | [fishnet](https://lichess.org/get-fishnet) | Distributed Stockfish analysis for lichess.org | [Upstream](https://github.com/niklasf/fishnet) |  |
-| FitTrackee |  | [Upstream](https://github.com/SamR1/FitTrackee) |  |
 | FlareSolverr | Proxy server to bypass Cloudflare protection | [Upstream](https://github.com/FlareSolverr/FlareSolverr) | |
 | Flask | Skeleton for flask apps |  | [Package Draft](https://github.com/YunoHost-Apps/flask_ynh) |
 | [foodsoft](https://foodcoops.github.io/foodsoft-hosting/) | Manage a non-profit food cooperative |  | [Package Draft](https://github.com/YunoHost-Apps/foodsoft_ynh) |


### PR DESCRIPTION
[Fittrackee](https://github.com/YunoHost-Apps/fittrackee_ynh) is already packaged and currently has integration level 7. I just spotted it on the wishlist and removed it.