### PR TITLE
Fix docs for `yunohost user group update` command which no longer exists

### DIFF
--- a/pages/02.administer/15.admin_guide/20.users/05.groups_and_permissions/groups_and_permissions.fr.md
+++ b/pages/02.administer/15.admin_guide/20.users/05.groups_and_permissions/groups_and_permissions.fr.md
@@ -87,10 +87,10 @@ Pour supprimer un utilisateur, cliquez sur la croix à côté de son nom d'utili
 En ligne de commande, utilisez la commande suivante pour ajouter `charlie` et `delphine` au groupe `yolo_crew` :
 
 ```shell
-$ yunohost user group update yolo_crew --add charlie delphine
+$ yunohost user group add yolo_crew charlie delphine
 ```
 
-(De même, `--remove` peut être utilisé pour retirer des membres d'un groupe.)
+(De même, `remove` peut être utilisé pour retirer des membres d'un groupe.)
 
 Dans la liste des groupes, nous devrions voir :
 

--- a/pages/02.administer/15.admin_guide/20.users/05.groups_and_permissions/groups_and_permissions.md
+++ b/pages/02.administer/15.admin_guide/20.users/05.groups_and_permissions/groups_and_permissions.md
@@ -90,10 +90,10 @@ To remove a user, click on the cross next to their username, in the group panel.
 In CLI, use the following command to add `charlie` and `delphine`to the `yolo_crew` group:
 
 ```shell
-$ yunohost user group update yolo_crew --add charlie delphine
+$ yunohost user group add yolo_crew charlie delphine
 ```
 
-(similarly, `--remove` can be used to remove members from a group)
+(similarly, `remove` can be used to remove members from a group)
 
 Now in the group list we should see:
 


### PR DESCRIPTION
Following the current example from the docs doesn't work to add user to group.

```
+ yunohost user group update privileged --add member1
usage: yunohost user group {list,create,delete,info,add,remove,add-mailalias,remove-mailalias} ... [-h]
yunohost user group: error: argument {list,create,delete,info,add,remove,add-mailalias,remove-mailalias}: invalid choice: 'update' (choose from 'list', 'create', 'delete', 'info', 'add', 'remove', 'add-mailalias', 'remove-mailalias')
```

Now there is `yunohost user group add GROUPNAME USERNAME...` command instead.