### PR TITLE
Update change_admin_password.md

### DIFF
--- a/pages/02.administer/50.troubleshooting/10.admin_password/change_admin_password.md
+++ b/pages/02.administer/50.troubleshooting/10.admin_password/change_admin_password.md
@@ -24,5 +24,5 @@ Then go to Tools > Change administration password.
 
 
 ```bash
-yunohost tools adminpw
+yunohost tools rootpw
 ```


### PR DESCRIPTION
yunohost tools adminpw doesn't work. yunohost itself states to use rootpw instead. corrected documentation. off to a great start, i am!