### PR TITLE
Update packaging_apps_intro.md : add cryptpad as an example for nodejs

### DIFF
--- a/pages/06.contribute/10.packaging_apps/packaging_apps_intro.md
+++ b/pages/06.contribute/10.packaging_apps/packaging_apps_intro.md
@@ -112,6 +112,6 @@ Unless you really want to start from scratch or from [`example_ynh`](https://git
 TODO/FIXME : here we should list a bunch of well-knowh apps for classic technologies
 
 - PHP apps:
-- NodeJS apps:
+- NodeJS apps: [cryptpad](https://apps.yunohost.org/app/cryptpad)
 - Python apps:
 - ???


### PR DESCRIPTION
The last part of the document shows examples of apps for different technologies. As cryptpad is already packaged in Yunohost, it can be used as an example to package other NodeJS apps.