### PR TITLE
Fix typo in Update isp.md

### DIFF
--- a/pages/02.administer/55.providers/10.isp/isp.md
+++ b/pages/02.administer/55.providers/10.isp/isp.md
@@ -32,7 +32,7 @@ Here is a non-comprehensive list of internet service providers by country, which
  * [South Korea](/isp/country:kor)
 
 [/ui-tab]
-[ui-tab title="Europa"]
+[ui-tab title="Europe"]
 
  * [Belgium (nl)](/isp/country:belnl)
  * [Belgium (fr)](/isp/country:belfr)


### PR DESCRIPTION
Yes, it’s stilly, I know. We call it Evropa / Europa too, but in English it’s Europe.