### PR TITLE
Installation guide patch

### DIFF
--- a/pages/02.administer/10.install/25.installing_debian/installing_debian.md
+++ b/pages/02.administer/10.install/25.installing_debian/installing_debian.md
@@ -50,5 +50,6 @@ The installer will ask about which **desktop environment** you want. You should 
 1. Remove the installation media (unplug the USB stick) 
 2. Reboot
 3. Login as `root` with the long complex password you created earlier.
-4. Proceed to install Yunohost on Debian using these instructions: https://yunohost.org/en/install/hardware:vps_debian
-
+4. Install curl by typing `apt install curl`
+5. Proceed to install Yunohost on Debian using these instructions: https://yunohost.org/en/install/hardware:vps_debian
+   - The installer will ask for permission to overwrite some configuration files. Select Yes.

--- a/pages/02.administer/10.install/25.installing_debian/installing_debian.md
+++ b/pages/02.administer/10.install/25.installing_debian/installing_debian.md
@@ -1,0 +1,54 @@
+---
+title: Installing Debian for Yunohost
+template: docs
+taxonomy:
+    category: docs
+routes:
+  default: '/installing_debian'
+---
+
+If you can't install Yunohost successfully, there's always the option to install Debian and then install Yunohost on top.
+
+## Which Debian version
+
+At the time of writing, only Debian 11 is supported by Yunohost. Don't use Debian 12.
+
+## Before you start
+
+The Debian installer isn't the easiest Linux installer, especially for beginners. It'll be easier to **format the hard drive** you plan to use for Debian+Yunohost **before you install Debian**, using your disk utility of choice.
+
+## Installing Debian
+
+### Booting the installer
+
+This guide won't go into details on how to boot the Debian installer. You can use Debian's own documentation for that. The short version is you'll need to flash a USB stick with the Debian 11 image, like you would flash the Yunohost image.
+
+### Installing
+
+In general, you can simply follow the instructions on screen and use the suggested defaults.
+
+Debian installer will ask for a **hostname** and a **domain name**. You can use “yunohost” and “yunohost.local”. It’s not really important since the Yunohost Installer will overwrite those anyway.
+
+Debian will ask for a **root password**. Make sure you pick a **really long and complex** one and save it to your password manager of choice (Bitwarden, Firefox, etc…) or write it somewhere safe. Remember that this is a server that  will be available on the internet, making it vulnerable to possible attacks so you should be extra safe here!
+
+The installer will also ask for a **user account** and another password. **Important:** name it something that won’t be used by your Yunohost server later. For example, you can name it `debian`. Be sure to also use a long complex password.
+
+When the install asks about where to install and how to **create disk partitions**, select the option to use the whole disk, unless you know what you're doing.
+
+- Don’t separate the /home, /var or /tmp partitions. Use the option to “keep all files in one partition”.
+- Don’t encrypt any partitions, [as recommended](https://yunohost.org/en/administer/install/hardware:regular#about-encryption))
+
+The installer will ask about **mirrors**. Select a country and server close to your location, or use the default options.
+
+The installer will ask about which **desktop environment** you want. You should not install a desktop environment on a server:
+
+- Unselect all desktop environment
+- Keep “standard system utilities” checked
+
+## After installing Debian
+
+1. Remove the installation media (unplug the USB stick) 
+2. Reboot
+3. Login as `root` with the long complex password you created earlier.
+4. Proceed to install Yunohost on Debian using these instructions: https://yunohost.org/en/install/hardware:vps_debian
+

--- a/pages/02.administer/10.install/install.fr.md
+++ b/pages/02.administer/10.install/install.fr.md
@@ -335,6 +335,17 @@ Pour les anciens matériels, il vous faut peut-être utiliser un CD/DVD. Le logi
 * Sur GNU/Linux, vous avez plusieurs choix, tels que [Brasero](https://wiki.gnome.org/Apps/Brasero) ou [K3b](http://www.k3b.org/)
 
 [/ui-tab]
+[ui-tab title="Utiliser Ventoy"]
+Ventoy sera utile si vous n'arrivez pas à démarrer l'image de Yunohost en utilisant les autres méthodes
+
+[Ventoy](https://www.ventoy.net/) est un outil pratique qui permet de mettre plusieurs images Linux sur une même clé USB et démarrer ces images sans devoir re-flasher la clé USB à chaque fois. C'est aussi pratique pour démarer une image qui refuse de démarrer: Ventoy réussi habituellement à tout démarrer!
+1. Installer [Ventoy](https://www.ventoy.net/) sur la clé USB. Référez-vous aux [instructions d'installation](https://www.ventoy.net/en/doc_start.html).
+    - Cela va créer 2 partition sur la clé USB.
+3. En utilisant votre application de fichiers préférée, copiez l'image Yunohost sur la grande partition "Ventoy (pas celle "VTOYEFI")
+    - N'utilisez pas *Balena Etcher*, USBImager ou `dd` pour faire ça!
+
+Insérez cette clé USB dans l'ordinateur et démarrez en utisant celle-ci. Ventoy va apparaitre et lister toutes les images qui sont sur la clé USB. Sélectionnez l'image de Yunohost. Sélectionnez ensuite "GRUB2" comme option de démarrage (ou utilisez n'importe laquelle qui fonctionnera sur votre ordinateur 😉)
+[/ui-tab]
 {% endif %}
 [/ui-tabs]
 
@@ -393,8 +404,10 @@ Démarrez votre machine virtuelle après avoir sélectionné l'image YunoHost.
 
 * Branchez le câble Ethernet (un côté à votre box, de l'autre côté à votre carte).
 * Démarrez votre serveur avec la clé USB ou le CD-ROM inséré, et sélectionnez-le comme **périphérique de démarrage (bootable device)** en pressant l’une des touches suivantes (dépendant de votre ordinateur) :
-`<ESC>`, `<F9>`, `<F10>`, `<F11>`, `<F12>` or `<DEL>`.
+`<F9>`, `<F10>`, `<F11>`, `<F12>`, `<DEL>`, `<ESC>` ou <Alt>.
     * N.B. : si le serveur était précédemment installé avec une version récente de Windows (8+), vous devez d'abord demander à Windows de « redémarrer réellement ». Vous pouvez le faire dans une option du menu « Options de démarrage avancées ».
+ 
+!!! Si vous n'arrivez pas à démarrer l'image Yunohost, essayez d'utiliser Ventoy (sélectionnez "Ventoy" dans la section "Flasher l'image YunoHost" ci-dessus).
 {% endif %}
 
 {% if regular or virtualbox %}
@@ -458,6 +471,7 @@ Ne perdez pas de vue que:
 [/ui-tab]
 [/ui-tabs]
 
+!!! Si l'installation de Yunohost échoue sur votre machine et que vous n'arrivez pas à résoudre le problème, sachez qu'il est aussi possible d'installer Debian et ensuite d'installer Yunohost dessus. Pour les instructions, au sommet de cette page, sélectionnez "Serveur distant" puis "VPS ou serveur dédié avec Debian".
 {% endif %}
 
 

--- a/pages/02.administer/10.install/install.md
+++ b/pages/02.administer/10.install/install.md
@@ -468,6 +468,17 @@ For older devices, you might want to burn a CD/DVD. The software to use depends 
 
 * On GNU/Linux, you have plenty of choices, like [Brasero](https://wiki.gnome.org/Apps/Brasero) or [K3b](http://www.k3b.org/)
 [/ui-tab]
+[ui-tab title="Using Ventoy"]
+Ventoy will be useful if you can't sucessfully boot the Yunohost image using the other methods.
+
+[Ventoy](https://www.ventoy.net/) is a nice tool that makes it really easy to put multiple linux images on a USB stick. When the computer refuses to boot from an image on a usb stick, Ventoy will usually be able to boot it anyway!
+1. Install [Ventoy](https://www.ventoy.net/) on the USB stick. Refer to the [install instructions](https://www.ventoy.net/en/doc_start.html).
+    - This will create 2 partitions on the stick.
+3. Using your favorite file explorer app, copy the Yunohost image file on the big `Ventoy` partition (not "VTOYEFI")
+    - Don't use *Balena Etcher*, USBImager or `dd` for this!
+
+Later, when you'll boot the computer using this usb stick, Ventoy will appear and will list the images on the USB stick. Select the Yunohost image, then select GRUB2 launch option (or use whichever works for your computer 😉)
+[/ui-tab]
 {% endif %}
 [/ui-tabs]
 
@@ -526,9 +537,11 @@ Start the virtual machine after selecting the YunoHost image.
 ## [fa=plug /] Boot the machine on your USB stick
 
 * Plug the ethernet cable (one side on your main router, the other on your server).
-* Boot up your server with the USB stick or a CD-ROM inserted, and select it as **bootable device** by pressing one of the following keys (hardware specific):
-`<ESC>`, `<F9>`, `<F10>`, `<F11>`, `<F12>` or `<DEL>`.
+* Boot up your server with the USB stick or a CD-ROM inserted, and select it as **bootable device**. Depending on your hardware, you will need to press one of the following keys:
+`<F9>`, `<F10>`, `<F11>`, `<F12>`, `<DEL>`, `<ESC>` or `<Alt>`.
     * N.B. : if the server was previously installed with a recent version of Windows (8+), you first need to tell Windows, to "actually reboot". This can be done somewhere in "Advanced startup options".
+
+!!! If you can't boot the Yunohost image, try using Ventoy (select "Ventoy" in the section "Flash the YunoHost image" above).
 {% endif %}
 
 {% if regular or virtualbox %}
@@ -592,6 +605,8 @@ Keep in mind that:
 
 [/ui-tab]
 [/ui-tabs]
+
+!!! If the Yunohost installer fails and you can't solve the issue, know that it's also possible to install Debian and then install Yunohost on top. For instructions, at the top of this page, select "Remote server", then "VPS or dedicated server with Debian".
 {% endif %}
 
 


### PR DESCRIPTION
- Instructions on how to boot the image using Ventoy if you can’t boot it normally
- Add a hint in “normal computer” to say that it’s also possible to install debian and install yunohost on top.
- Add a new page with instructions on how to install Debian for Yunohost