### PR TITLE
add fail2ban configuration to nextcloud doc

### DIFF
--- a/pages/04.applications/10.docs/nextcloud/app_nextcloud.fr.md
+++ b/pages/04.applications/10.docs/nextcloud/app_nextcloud.fr.md
@@ -135,6 +135,23 @@ sudo -u nextcloud php8.1 --define apc.enable_cli=1 files:scan --all
 
 C'est terminé. À présent testez si tout va bien, essayez de vous connecter à votre instance Nextcloud, envoyer un fichier, vérifiez sa bonne synchronisation.
 
+##### Configurer Fail2ban
+Modifiez la configuration de fail2ban
+```bash
+nano /etc/fail2ban/jail.d/nextcloud.conf
+```
+Que vous modifiez:
+```bash
+CAS A : logpath = /media/stockage/nextcloud/data/nextcloud.log
+CAS B : logpath = /media/stockage/nextcloud_data/nextcloud/data/nextcloud.log
+```
+Sauvegardez avec `ctrl+x` puis `y` ou `o` (dépend de la locale de votre serveur).
+
+Redémarrez fail2ban
+```bash
+systemctl restart fail2ban
+```
+
 ### Partager un dossier entre Nextcloud et une application
 Il est relativement simple de monter des dossiers accessibles depuis Nextcloud en lecture/écriture et de les 
 partager avec d'autres applications (par exemple [Jellyfin](app_jellyfin), [Funkwhale](app_funkwhale), [Transmission](app_transmission), ...)

--- a/pages/04.applications/10.docs/nextcloud/app_nextcloud.md
+++ b/pages/04.applications/10.docs/nextcloud/app_nextcloud.md
@@ -141,6 +141,24 @@ Case B: yunohost app setting nextcloud datadir -v /media/storage/nextcloud_data/
 
 It's over now. Now test if everything is fine, try connecting to your Nextcloud instance, upload a file, check its proper synchronization.
 
+##### Configure Fail2ban
+Modify fail2ban configuration 
+```bash
+nano /etc/fail2ban/jail.d/nextcloud.conf
+```
+
+That you modify:
+```bash
+Case A : logpath = /media/storage/nextcloud/data/nextcloud.log
+Case B : logpath = /media/storage/nextcloud_data/nextcloud/data/nextcloud.log
+```
+Save it with `ctrl+x` then `y` or `o` (depending on your server locale).
+
+Restart fail2ban
+```bash
+systemctl restart fail2ban
+```
+
 ### Nextcloud and Cloudflare
 
 If you use Cloudflare for your DNS, *which may be useful if you have a dynamic IP*, you will most likely have authentication problems with the Nextcloud application. On the Internet many people propose to create a rule that disables all options related to security and Cloudflare speed for the URL pointing to your Nextcloud instance. Although it works, it is not the optimal solution. I propose, certainly to create a rule for the URL pointing to your Nextcloud instance but to disable only 2 options. So here's how:


### PR DESCRIPTION
I added a section in nextcloud documentation to update fail2ban log path.

Let me know if this is rather a bug with `yunohost app setting nextcloud datadir -v /media/storage` that would update fail2ban.
