### PR TITLE
Update Nextcloud app documentation to fix wrong command

### DIFF
--- a/pages/04.applications/10.docs/nextcloud/app_nextcloud.md
+++ b/pages/04.applications/10.docs/nextcloud/app_nextcloud.md
@@ -195,7 +195,7 @@ Save the file (**CTRL** + **o**) and exit nano (**CTRL** + **c**).
 Then run a scan by executing next command as root:
 
 ```bash
-sudo -u nextcloud php8.1 --define apc.enable_cli=1 files:scan --all
+sudo -u nextcloud php8.1 --define apc.enable_cli=1 occ files:scan --all
 ```
 
 Now the problem is fixed.


### PR DESCRIPTION
The last command to scan for new files after migrating nextcloud data directory lacks the actual command `occ` to make the command work properly. See: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/occ_command.html#scan