### PR TITLE
add PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Problem
+
+- *Description of why you made this PR, what is its purpose*
+
+## Solution
+
+- *And how do you fix relevantly that problem*
+
+## PR checklist
+
+- [ ] I'm not doing a PR for an application, I promise, I know that this kind of changes must go directly into the app packages themselves
+- [ ] PR finished and ready to be reviewed


### PR DESCRIPTION
## Problem

- we need people to explain clearly ***why*** their PR, to simplify the reviewing work of volunteers
- we need to advertise more clearly that apps' docs are NOT here
- we need to know clearly if the PR is ready to be reviewed

## Solution

- `PULL_REQUEST_TEMPLATE.md` is relevant for that

## PR checklist

- [x] I'm not doing a PR for an application, I promise, I know that this kind of changes must go directly into the app packages themselves
- [x] PR finished and ready to be reviewed