### PR TITLE
add ## Ask in the right place

### DIFF
--- a/pages/07.help/help.fr.md
+++ b/pages/07.help/help.fr.md
@@ -9,16 +9,23 @@ routes:
 
 Bien que les personnes contribuant à YunoHost essaient continuellement de l'améliorer, YunoHost ou sa documentation ne sont exempts de bugs ou d'erreurs. Pour nous aider à vous aider, vous devez cependant suivre ces instructions.
 
-Le support n'est prodigué que sur [le forum](https://forum.yunohost.org?target=_blank) ou sur [nos salons de discussion](/chat_rooms?target=_blank).  
-Nous avons un compte Mastodon, mais nous ne prodiguons pas d'aide sur cette plateforme.
-
-Pour que nous puissions être en mesure de vous aider sur le forum, vous devez impérativement remplir le modèle de demande de support qui s'affichera lors de la création du message.
-
 # À faire
 
 ## Patience et courtoisie
 
 L'aide dans les salons de discussion ou sur le forum est apportée par des personnes entièrement bénévoles. Peut-être que vous-vous sentez sous pression, que les essais infructueux vous épuisent ou encore que de mauvaises émotions vous submergent... Faites une pause, buvez une gorgée de votre boisson apaisante préférée, soufflez, et une fois votre contenance revenue, poursuivez votre lecture. Nous avons besoin de vous dans un bon état d'esprit pour vous aider.
+
+## Demandez au bon endroit
+
+Le support n'est prodigué que sur [le forum](https://forum.yunohost.org?target=_blank) ou sur [nos salons de discussion](/chat_rooms?target=_blank).  
+Nous avons un compte Mastodon, mais nous ne prodiguons pas d'aide sur cette plateforme.
+
+Sur le forum, assurez-vous d'ouvrir votre demande dans la bonne catégorie, afin de maximiser vos chances de recevoir l'aide appropriée :
+
+- [Support](https://forum.yunohost.org/c/support/6?target=_blank) pour les problèmes lors de l'installation ou de l'utilisation de YunoHost en soit ;
+- [Support apps](https://forum.yunohost.org/c/apps/11?target=_blank) pour les problèmes lors de la configuration ou de l'utilisation d'applications.
+
+Pour que nous puissions être en mesure de vous aider sur le forum, vous devez impérativement remplir le modèle de demande de support qui s'affichera lors de la création du message.
 
 ## Expliquez le contexte
 
@@ -33,7 +40,7 @@ YunoHost fournit des boutons verts "Partager avec YunoPaste" lorsque quelque cho
 
 Il est recommandé de partager ces logs dans leur intégralité à l'aide du lien généré par YunoPaste.  
 Évitez les extraits de logs, une information déterminante est peut-être ailleurs.  
-Évitez aussi de les copier-coller de manière brutte dans le forum, car c'est désagréable de les parcourir comme ça, partagez le lien de YunoPaste.
+Évitez aussi de les copier-coller de manière brute dans le forum, car c'est désagréable de les parcourir comme ça, partagez le lien de YunoPaste.
 
 ![Bouton YunoPaste](image://yunopaste.png)
 

--- a/pages/07.help/help.md
+++ b/pages/07.help/help.md
@@ -9,16 +9,23 @@ routes:
 
 Even though YunoHost contributors try to continuously perfect it, YunoHost itself or this documentation are not free from bugs or flaw. To let us help you, however, you need to follow these guidelines.
 
-Support is only available on [the forum](https://forum.yunohost.org?target=_blank) or our [chatrooms](/chat_rooms?target=_blank).  
-We are also on Mastodon, but we do not offer help on this platform.
-
-To allow us to help you on the forum, you absolutely need to fill in the Support request template, it will be displayed on message creation.
-
 # Dos
 
 ## Be courteous and patient
 
 Help in the chatrooms or on the forum is given by our users and contributors, all volunteers. You may be in a hurry, you may be exhausted by fruitless trials or overwhelmed by unpleasant emotions... Have a break, have a sip of your preferred soothing beverage, breathe and once you've recovered your composure continue reading. We need you in a good mindset to help you.
+
+## Ask in the right place
+
+Support is only available on [the forum](https://forum.yunohost.org?target=_blank) or our [chatrooms](/chat_rooms?target=_blank).  
+We are also on Mastodon, but we do not offer help on this platform.
+
+On the forum, make sure you open your request in the proper category, to maximize your chances of receiving appropriate help:
+
+- [Support](https://forum.yunohost.org/c/support/6?target=_blank) for issues when setting up or using YunoHost itself;
+- [Support apps](https://forum.yunohost.org/c/apps/11?target=_blank) for issues when setting up or using apps.
+
+To allow us to help you on the forum, you absolutely need to fill in the Support request template, it will be displayed on message creation.
 
 ## Explain the context
 


### PR DESCRIPTION
## Problem

- the text explaining where to ask for support is not in the `Dos` section

## Solution

- add `## Ask in the right place` after `# Dos ## Be courteous and patient`
- move the existing text about the chat and forum
- explain the forum support categories

## PR checklist

- [x] I'm not doing a PR for an application, I promise, I know that this kind of changes must go directly into the app packages themselves
- [x] PR finished and ready to be reviewed
