### PR TITLE
Update install.md

### DIFF
--- a/pages/02.administer/10.install/install.md
+++ b/pages/02.administer/10.install/install.md
@@ -269,8 +269,7 @@ sudo apt install -y dotnet-sdk-3.1
 
 ```bash
 # In WSL
-# Add their repository
-echo "deb [trusted=yes] https://wsl-translinux.arkane-systems.net/apt/ /" > /etc/apt/sources.list.d/wsl-translinux.list
+# Follow the guide on https://arkane-systems.github.io/wsl-transdebian/ to install wsl-transdebian (translinux is deprecated)
 # Install Genie
 sudo apt update
 sudo apt install -y systemd-genie


### PR DESCRIPTION
Transdebian repo url isn't available anymore, update guide with relevant tutorial + link from official source

## Problem

- Failing to add transdebian repo to apt lists in order to install genie

## Solution

- Update deprecated url with correct one (translinux) as advised by "https://arkane-systems.github.io/wsl-transdebian/" - (official link)
 
## Caveat

- Systemd setup was required ( and is required ) for this to work - possibly needs more elaborated guide (explanation) on lsb-release installation

## PR checklist

- [X] I'm not doing a PR for an application, I promise, I know that this kind of changes must go directly into the app packages themselves
- [X] PR finished and ready to be reviewed
