### PR TITLE
Adding applications examples

### DIFF
--- a/pages/06.contribute/10.packaging_apps/packaging_apps_intro.fr.md
+++ b/pages/06.contribute/10.packaging_apps/packaging_apps_intro.fr.md
@@ -112,7 +112,7 @@ A moins que vous ne souhaitiez vraiment partir de zéro ou de [`example_ynh`](ht
 
 TODO/FIXME : here we should list a bunch of well-knowh apps for classic technologies
 
-- Applications PHP :
+- Applications PHP : [my_webapp](https://github.com/YunoHost-Apps/my_webapp_ynh/)
 - Applications NodeJS :
-- Applications Python :
+- Applications Python : [FastAPI](https://github.com/YunoHost-Apps/FastAPI_ynh/)
 - ???


### PR DESCRIPTION
## Problem
There was a todo in the documentation with a list of example to fill
## Solution
I Added my_webapp as example of packaging a PHP application
I also added FastAPI as example of packaging a python application

I use both applications, and their code is light so I think they are good application to start packaging other PHP or python app's

## PR checklist

- [ ] I'm not doing a PR for an application, I promise, I know that this kind of changes must go directly into the app packages themselves
- [ ] PR finished and ready to be reviewed
