### PR TITLE
Fail2ban whitelist

### DIFF
--- a/pages/02.administer/50.troubleshooting/05.fail2ban/fail2ban.md
+++ b/pages/02.administer/50.troubleshooting/05.fail2ban/fail2ban.md
@@ -60,13 +60,66 @@ When updating the **Fail2Ban** software, the original `/etc/fail2ban/jail.conf` 
     ```bash
     [DEFAULT]
 
-    ignoreip = 127.0.0.1/8 XXX.XXX.XXX.XXX #<= the IP address (you can put more than one, separated by a space) that you want to whitelist
+    ignoreip = 127.0.0.1/8 XXX.XXX.XXX.XXX ; <= the IP address (you can put more than one, separated by a space) that you want to whitelist
     ```
 
-4. Save the file and reload the Fail2Ban configuration:
+4. You should get end up with something like this if you have added two ip addresses (ipv4 and [ipv6](/ipv6))
+
+    ```bash
+    [DEFAULT]
+
+    ignoreip = 127.0.0.1/8 203.0.113.4 2001:DB8::1
+    ```
+
+5. Save the file and reload the Fail2Ban configuration:
 
     ```bash
     sudo fail2ban-client reload
     ```
+
+6. Check that the configuration has been applied as expected:
+
+    1. You should have this result
+
+        ```bash
+        root@sambain:/etc/nginx# fail2ban-client get sshd ignoreip
+        These IP addresses/networks are ignored:
+        |- 127.0.0.0/8
+        |- 2001:db8::1
+        |- XXX.XXX.XXX.XXX
+        `- 203.0.113.4
+        ```
+
+    2. If there is an error with your change, you could end up with something like this:
+
+        ```bash
+        sudo fail2ban-client get sshd ignoreip
+        These IP addresses/networks are ignored:
+        |- 127.0.0.0/8
+        |- #<=
+        |- the
+        |- IP
+        |- address
+        |- (you
+        |- can
+        |- put
+        |- more
+        |- than
+        |- one
+        |- separated
+        |- by
+        |- a
+        |- space)
+        |- that
+        |- you
+        |- want
+        |- to
+        |- whitelist
+        |- 203.0.113.4
+        |- XXX.XXX.XXX.XXX
+        `- 2001:db8::1
+        ```
+
+        For the curious, it was because of a [comment ;](https://github.com/fail2ban/fail2ban/blob/master/config/jail.conf#L30)
 
 Congratulations, no more risks of banning yourself from your own YunoHost server!

--- a/pages/02.administer/50.troubleshooting/05.fail2ban/fail2ban.md
+++ b/pages/02.administer/50.troubleshooting/05.fail2ban/fail2ban.md
@@ -57,10 +57,14 @@ When updating the **Fail2Ban** software, the original `/etc/fail2ban/jail.conf` 
 
 3. Paste the following content into the file and adapt the IP address `XXX.XXX.XXX.XXX`:
 
+    ! Keep the `127.0.0.1/8`, it corresponds to the server [internal communication system](https://en.wikipedia.org/wiki/Localhost)
+
     ```bash
     [DEFAULT]
 
-    ignoreip = 127.0.0.1/8 XXX.XXX.XXX.XXX ; <= the IP address (you can put more than one, separated by a space) that you want to whitelist
+    ignoreip = 127.0.0.1/8 XXX.XXX.XXX.XXX
+    #                      ^ Add your IP address or DNS host here
+    #                        you can put more than one, separated by a space
     ```
 
 4. You should get end up with something like this if you have added two ip addresses (ipv4 and [ipv6](/ipv6))
@@ -71,13 +75,13 @@ When updating the **Fail2Ban** software, the original `/etc/fail2ban/jail.conf` 
     ignoreip = 127.0.0.1/8 203.0.113.4 2001:DB8::1
     ```
 
-5. Save the file and reload the Fail2Ban configuration:
+5. **Save** the file and **reload** the Fail2Ban configuration:
 
     ```bash
     sudo fail2ban-client reload
     ```
 
-6. Check that the configuration has been applied as expected:
+6. **Check** that the configuration has been applied as expected:
 
     1. You should have this result
 
@@ -90,7 +94,7 @@ When updating the **Fail2Ban** software, the original `/etc/fail2ban/jail.conf` 
         `- 203.0.113.4
         ```
 
-    2. If there is an error with your change, you could end up with something like this:
+    2. If there is an **error** with your change, you could end up with something like this:
 
         ```bash
         sudo fail2ban-client get sshd ignoreip
@@ -120,6 +124,8 @@ When updating the **Fail2Ban** software, the original `/etc/fail2ban/jail.conf` 
         `- 2001:db8::1
         ```
 
-        For the curious, it was because of a [comment ;](https://github.com/fail2ban/fail2ban/blob/master/config/jail.conf#L30)
+        And you will need to fix it or revert your changes as Fail2ban could fail
+
+        > For the curious, it was because of a [comment ;](https://github.com/fail2ban/fail2ban/blob/master/config/jail.conf#L30)
 
 Congratulations, no more risks of banning yourself from your own YunoHost server!


### PR DESCRIPTION
## Problem

- error in documentation made a nextcloud upgrade to fail (as fail2ban was broken, the upgrade failed)

## Solution
- fix the doc
- proposal to enhance it


## Solution long term
why not integrate the file `yunohost-whitelist.conf` in the "core" so people don't have to create it by hand . Could it be doable and where/how add it to the backlog  ?

I have no idea of the "complexity" of it. Here is how I see it:

1. create the file
    1. copy the relevent part of [fail2ban/jail.conf](https://github.com/YunoHost/yunohost/blob/dev/conf/fail2ban/jail.conf#L41-L50) or take the one of this doc
    2. Create file https://github.com/YunoHost/yunohost/blob/dev/conf/fail2ban/yunohost-whitelist.conf
2. Add it to the "core"
    1. https://github.com/YunoHost/yunohost/blob/dev/hooks/conf_regen/52-fail2ban#L18
3. Problems
    1. how to manage existing whitelist config files and content ?
    2. Upgrades by YunoHost ?

- *And how do you relevantly fix that problem*

## PR checklist

- [x] I'm not doing a PR for an application, I promise, I know that this kind of changes must go directly into the app packages themselves
- [x] PR finished and ready to be reviewed
