### PR TITLE
Add link to guide on how to install Debian for Yunohost

### DIFF
--- a/pages/02.administer/10.install/install.fr.md
+++ b/pages/02.administer/10.install/install.fr.md
@@ -468,7 +468,7 @@ Ne perdez pas de vue que:
 [/ui-tab]
 [/ui-tabs]
 
-!!! Si l'installation de YunoHost échoue sur votre machine et que vous n'arrivez pas à résoudre le problème, sachez qu'il est aussi possible d'installer Debian et ensuite d'installer YunoHost dessus. Pour les instructions, au sommet de cette page, sélectionnez "Serveur distant" puis "VPS ou serveur dédié avec Debian".
+!!! Si l'installation de YunoHost échoue sur votre machine et que vous n'arrivez pas à résoudre le problème, sachez qu'il est aussi possible d'installer Debian et ensuite d'installer YunoHost dessus. Voir ces instructions: https://yunohost.org/fr/administer/install/installing_debian
 {% endif %}
 
 {% if rpi012 %}

--- a/pages/02.administer/10.install/install.md
+++ b/pages/02.administer/10.install/install.md
@@ -613,7 +613,7 @@ Keep in mind that:
 [/ui-tab]
 [/ui-tabs]
 
-!!! If the YunoHost installer fails and you can't solve the issue, know that it's also possible to install Debian and then install YunoHost on top. For instructions, at the top of this page, select "Remote server", then "VPS or dedicated server with Debian".
+!!! If the YunoHost installer fails and you can't solve the issue, know that it's also possible to install Debian and then install YunoHost on top. See these instructions: https://yunohost.org/en/installing_debian
 {% endif %}
 
 {% if rpi012 %}


### PR DESCRIPTION
## Problem

- The note about installing Debian if the yunohost image cannot boot (on regular computer) didn't link to the correct page.

## Solution

- Add link to the guide on how to install Debian for Yunohost

## PR checklist

- [ ] PR finished and ready to be reviewed
