### PR TITLE
detailed 'accept' parameter of file type question  

### DIFF
--- a/pages/06.contribute/15.dev/03.forms/forms.md
+++ b/pages/06.contribute/15.dev/03.forms/forms.md
@@ -130,7 +130,7 @@ File question
 
 | Property | Description  | Example |
 |----------|--------------|---------|
-| `accept`    | Accepted MIME types, as in [HTML implementation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) | `["image/png"]` or `["image/*"]` or `["image/png, image/jpeg"]` |
+| `accept`    | Accepted MIME types, as in [HTML implementation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) | `["image/png"]` or `["image/*"]` or `["image/png", "image/jpeg"]` |
 
 ! This file type is not made for big files transfer, it's just for small logo, or config files.
 

--- a/pages/06.contribute/15.dev/03.forms/forms.md
+++ b/pages/06.contribute/15.dev/03.forms/forms.md
@@ -130,7 +130,7 @@ File question
 
 | Property | Description  | Example |
 |----------|--------------|---------|
-| `accept`    | Same format than HTML file input |         |
+| `accept`    | Accepted MIME types, as in [HTML implementation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) | `["image/png"]` or `["image/*"]` or `["image/png, image/jpeg"]` |
 
 ! This file type is not made for big files transfer, it's just for small logo, or config files.
 


### PR DESCRIPTION
improved description and added examples.
The first example was successfully tested, as opposed to `[".png"] which was not working.
The 2 last examples have been copied from Mozilla's doc but have not been tested with YNH... would it rather be ["image/png", "image/jpeg"] ?