### PR TITLE
Update URL for auto update

### DIFF
--- a/pages/06.contribute/10.packaging_apps/10.manifest/10.appresources/packaging_app_manifest_resources.md
+++ b/pages/06.contribute/10.packaging_apps/10.manifest/10.appresources/packaging_app_manifest_resources.md
@@ -280,7 +280,7 @@ Or more complex examples with several element, including one with asset that dep
 
 Strictly speaking, this has nothing to do with the actual app install. `autoupdate` is expected to contain metadata for automatic maintenance / update of the app sources info in the manifest. It is meant to be a simpler replacement for "autoupdate" Github workflow mechanism.
 
-The infos are used by this script : <https://github.com/YunoHost/apps/blob/master/tools/autoupdate_app_sources/autoupdate_app_sources.py> which is ran by the YunoHost infrastructure periodically and will create the corresponding pull request automatically.
+The infos are used by this script : <https://github.com/YunoHost/apps_tools/blob/main/autoupdate_app_sources/autoupdate_app_sources.py> which is ran by the YunoHost infrastructure periodically and will create the corresponding pull request automatically.
 
 The script will rely on the code repo specified in `code` in the upstream section of the manifest.
 


### PR DESCRIPTION
updated the url for the `autoupdate_app_sources.py` script

## Problem

- `autoupdate_app_sources.py` has moved from YunoHost/apps to YunoHost/apps_tools the url under https://yunohost.org/ar/packaging_apps_resources#regarding-autoupdate is deprecated and throws an 404 

## Solution

- updated the url

## PR checklist

- [X] PR finished and ready to be reviewed
