### PR TITLE
Allow defining a custom_edit_link in doc pages

### DIFF
--- a/themes/yunohost-docs/templates/partials/github-link.html.twig
+++ b/themes/yunohost-docs/templates/partials/github-link.html.twig
@@ -1,0 +1,5 @@
+{% set edit_link = 
+    page.header.custom_edit_link is defined and page.header.custom_edit_link is not empty ? page.header.custom_edit_link :
+    github_config.tree ~  ('/'~page.filePathClean)|replace({'/user/':''})
+%}
+<a class="github-link tooltip tooltip-bottom" href="{{ edit_link }}" data-tooltip="Edit this page on GitHub"><i class="fa fa-pencil-square"></i> {{ 'THEME_LEARN4_GITHUB_EDIT'|t }}</a>


### PR DESCRIPTION
## Problem

https://yunohost.org/en/packaging_apps_resources
https://yunohost.org/en/packaging_apps_helpers
https://yunohost.org/en/packaging_apps_helpers_v2.1 

In above-mentioned doc pages, clicking 'Edit' at the top of the page leads to a .md file since these pages are exceptions which are generated via a script. This is being misleading for the people willing to edit the page.

![editdoc](https://github.com/user-attachments/assets/c005a0e6-6e6b-4348-8c0f-cce4f2e811ad)

## Solution

Add a custom `github-link.html.twig` template that checks whether the markdown file to be displayed has a `custom_edit_link` header. If it has one, then display it instead of the default link.

Thus, pages requiring a custom edit link would have a Grav header of this kind (cf. added `custom_edit_link` header):
```md
---
title: App helpers (v{{ helpers_version }})
template: docs
taxonomy:
    category: docs
routes:
  default: '/packaging_apps_helpers{% if helpers_version not in ["1", "2"] %}_v{{ helpers_version }}{% endif %}'
custom_edit_link: 'https://github.com/YunoHost/yunohost/tree/dev/helpers/helpers.v{{ helpers_version }}.d'
---
```
https://learn.getgrav.org/17/content/headers#custom-page-headers

## PR checklist

- [x] PR finished and ready to be reviewed

It has however not been tested on a deployed Grav instance.