### PR TITLE
typo in packaging_app_manifest_resources.md

### DIFF
--- a/pages/06.contribute/10.packaging_apps/10.manifest/10.appresources/packaging_app_manifest_resources.md
+++ b/pages/06.contribute/10.packaging_apps/10.manifest/10.appresources/packaging_app_manifest_resources.md
@@ -247,9 +247,9 @@ Or more complex examples with several element, including one with asset that dep
     armhf.sha256 = "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865"
 
     autoupdate.strategy = "latest_github_release"
-    autoupdate.asset.amd64 = ".*\.amd64.tar.gz"
-    autoupdate.asset.i386 = ".*\.386.tar.gz"
-    autoupdate.asset.armhf = ".*\.arm.tar.gz"
+    autoupdate.asset.amd64 = ".*\\.amd64.tar.gz"
+    autoupdate.asset.i386 = ".*\\.386.tar.gz"
+    autoupdate.asset.armhf = ".*\\.arm.tar.gz"
 
     [resources.sources.zblerg]
     url = "https://zblerg.com/download/zblerg"


### PR DESCRIPTION
        autoupdate.asset.amd64 = ".*\\.bookworm_amd64.deb"
        autoupdate.asset.arm64 = ".*\\.bookworm_arm64.deb"
instead of
        autoupdate.asset.amd64 = ".*\.bookworm_amd64.deb"
        autoupdate.asset.arm64 = ".*\.bookworm_arm64.deb"

## Problem

- *Description of why you made this PR, what is its purpose*

## Solution

- *And how do you relevantly fix that problem*

## PR checklist

- [ ] PR finished and ready to be reviewed
