### PR TITLE
Documentation update in Eng and Fra for the ssh connection after postinstall

### DIFF
--- a/pages/02.administer/15.admin_guide/15.command_line/command_line.fr.md
+++ b/pages/02.administer/15.admin_guide/15.command_line/command_line.fr.md
@@ -30,9 +30,9 @@ L'interface en ligne de commande (CLI) est, en informatique, la manière origina
 [/ui-tab]
 [ui-tab title="Après"]
 
-Durant la post-installation, vous avez défini un mot de passe d'administration. C'est ce mot de passe qui devient le nouveau mot de passe pour les utilisateurs `root` et `admin`. De plus, **la connexion en SSH avec l'utilisateur `root` est désactivée et il vous faut utiliser l'utilisateur `admin` !**. L'exception à cette règle est qu'il reste possible de se logger en root *depuis le réseau local - ou depuis une console en direct sur la machine* (ce qui peut être utile dans l'éventualité où le serveur LDAP est inactif et l'utilisateur admin ne fonctionne plus).
+Durant la post-installation, vous avez défini un compte et un mot de passe d'administration. Le compte défini lors de la post-installation vous permet de vous connecter en SSH. De plus, le mot de passe défini dans la post-installation devient le nouveau mot de passe pour l'utilisateur `root`. Enfin, **la connexion en SSH avec l'utilisateur `root` est désactivée et il vous faut utiliser le compte défini durant la post-installation !**. L'exception à cette règle est qu'il reste possible de se logger en root *depuis le réseau local - ou depuis une console en direct sur la machine* (ce qui peut être utile dans l'éventualité où le serveur LDAP est inactif et l'utilisateur admin ne fonctionne plus).
 
-!!! Si vous êtes connecté en tant qu'`admin` et souhaitez devenir `root` pour plus de confort (par exemple, ne pas avoir à taper `sudo` à chaque commande), vous pouvez devenir `root` en tapant `sudo su` ou `sudo -i`.
+!!! Si vous êtes connecté en tant avec le compte d'administration et souhaitez devenir `root` pour plus de confort (par exemple, ne pas avoir à taper `sudo` à chaque commande), vous pouvez devenir `root` en tapant `sudo su` ou `sudo -i`.
 [/ui-tab]
 [/ui-tabs]
 

--- a/pages/02.administer/15.admin_guide/15.command_line/command_line.md
+++ b/pages/02.administer/15.admin_guide/15.command_line/command_line.md
@@ -30,9 +30,9 @@ The command line interface (CLI) is, in the computer world, the original (and mo
 [/ui-tab]
 [ui-tab title="After"]
 
-During the postinstall, you've been asked to choose an administration password. This password becomes the new password for the `root` and `admin` users. Additionally, **the `root` SSH login becomes disabled after the postinstall and you should log in using the `admin` user !**. The only exception is that you may still be able to login using `root` *from the local network - or from a direct console on the server* (this is to cover the event where the LDAP server is broken and the `admin` user is unusable).
+During the postinstall, you've been asked to choose an user and an administration password. This user account allows you to connect to the server through SSH. The password becomes also the new password for the `root` user. Additionally, **the `root` SSH login becomes disabled after the postinstall and you should log in using the user account created during postinstall !**. The only exception is that you may still be able to login using `root` *from the local network - or from a direct console on the server* (this is to cover the event where the LDAP server is broken and the `admin` user is unusable).
 
-!!! If you connected as `admin` and would like to become `root` for convenience (e.g. to avoid typing `sudo` in front of every command), you can become `root` using the command `sudo su` or `sudo -i`.
+!!! If you connected with the administration account and would like to become `root` for convenience (e.g. to avoid typing `sudo` in front of every command), you can become `root` using the command `sudo su` or `sudo -i`.
 [/ui-tab]
 [/ui-tabs]
 


### PR DESCRIPTION
## Problem

- The documentation talks about a `root` and an `admin` user account. The `admin` account doesn't exist any more

## Solution

- The documentation has been updated in English and French to take into account that the account created during postinstall is the new administration account through SSH too.

## PR checklist

- [x] PR finished and ready to be reviewed
