### PR TITLE
clarify Restic app's supported storage types

### DIFF
--- a/pages/02.administer/20.backups/10.backup_methods/backup_methods.md
+++ b/pages/02.administer/20.backups/10.backup_methods/backup_methods.md
@@ -24,7 +24,7 @@ There are [remote borg repository providers](https://www.borgbackup.org/support/
 
 ## [Restic](https://restic.net/) (cf the [Restic app](https://apps.yunohost.org/app/restic))
 
-- backup of data to remote storage (support for different types of storage, inclusing S3 and SFTP)
+- backup of data to remote storage (support for different types of storage: currently SFTP, S3 is planned)
 - deduplication and compression of files, which makes it possible to keep many previous copies without too much storage overhead
 - data encryption, which allows to store data at a third party
 - to define the frequency and type of data to be backed up


### PR DESCRIPTION
## Problem

- https://github.com/YunoHost-Apps/restic_ynh/issues/27
- Since S3 is currently not suppert by the Restic app the documentation is quite misleading.

## Solution

- clarify the supported storage types

## PR checklist

- [x] PR finished and ready to be reviewed
