### PR TITLE
Update help.ar.md

### DIFF
--- a/pages/05.community/15.help/help.ar.md
+++ b/pages/05.community/15.help/help.ar.md
@@ -26,7 +26,7 @@ routes:
 <em>ملاحظة : يمكن الإتصال كذلك بغرفة المحادثة باستخدام تطبيق XMPP الخاص بك على العنوان التالي </br>
 support@conference.yunohost.org </br>
 <a target="_blank" href="https://web.libera.chat/#yunohost">kiwiirc</a>  باستخدام   libera.chat على #yunohost IRC أو </br>
-<a target="_blank" href="https://riot.im/app/#/room/#yunohost:matrix.org">Riot</a> باستخدام Matrix أو </br>
+<a target="_blank" href="https://matrix.to/#/#yunohost:matrix.org">Matrix أو</a> باستخدام Matrix أو </br>
 </em>
 </center>
 


### PR DESCRIPTION
Fixed url to https://matrix.to/#/#yunohost:matrix.org for joining the Matrix channel for Arabic speaking users.

## Problem

Fixed url to https://matrix.to/#/#yunohost:matrix.org for joining the Matrix channel for Arabic speaking users.

## Solution

Updated the URL:  https://matrix.to/#/#yunohost:matrix.org

## PR checklist

- [ ] PR finished and ready to be reviewed
