### PR TITLE
Update help.md

### DIFF
--- a/pages/05.community/15.help/help.md
+++ b/pages/05.community/15.help/help.md
@@ -30,7 +30,7 @@ Please change your username, as we got legions of `ynhuser`s.
 [/center]
 
 !!! **Note:** this room is available via
-!!! - Matrix (`#yunohost:matrix.org` [using Element](https://riot.im/app/#/room/#yunohost:matrix.org?target=_blank))
+!!! - Matrix (`#yunohost:matrix.org` [using any Matrix client](https://matrix.to/#/#yunohost:matrix.org))
 !!! - IRC (`#yunohost` on libera.chat, [using kiwiirc](https://web.libera.chat/#yunohost))
 !!! - XMPP (`xmpp:support@conference.yunohost.org?join`)
 


### PR DESCRIPTION
Fixed riot.im link to use https://matrix.to/#/#yunohost:matrix.org

## Problem

Searched codebase for riot.im and updated this document to use correct url to join "https://matrix.to/#/#yunohost:matrix.org"

## Solution

Added https://matrix.to/#/#yunohost:matrix.org into the code

## PR checklist

- [ ] PR finished and ready to be reviewed
