### PR TITLE
Add pointer for failed mailman3

### DIFF
--- a/pages/02.administer/15.admin_guide/55.upgrade/16.bullseye_bookworm/05.issues_faq/issues_faq.md
+++ b/pages/02.administer/15.admin_guide/55.upgrade/16.bullseye_bookworm/05.issues_faq/issues_faq.md
@@ -34,6 +34,9 @@ The web server, nginx, might need a restart before being fully operational. Plea
 sudo systemctl restart nginx
 ```
 
+## Mailman3 failed in diagnostics
+
+A manual change in a configuration file is needed for Mailman3 to work : https://github.com/YunoHost-Apps/mailman3_ynh/issues/48#issuecomment-2536194377
 
 <!-- ### Can't run the migration due to `libc6-dev : Breaks: libgcc-8-dev issue`
 


### PR DESCRIPTION
Mailman3 fails to work after upgrade. Pointed to the workaround

## Problem

- *After upgrade diagnosis points to Mailman3 failing*

## Solution

- *Editing a config file as a workaround, as suggested in the corresponding issue*

## PR checklist

- [x] PR finished and ready to be reviewed
