### PR TITLE
First start of documenting the use of basic-space-cleanup tool

### DIFF
--- a/pages/02.administer/50.troubleshooting/03.cleanup/cleanup.md
+++ b/pages/02.administer/50.troubleshooting/03.cleanup/cleanup.md
@@ -1,0 +1,17 @@
+---
+title: Cleanup
+template: docs
+taxonomy:
+    category: docs
+routes:
+  default: '/cleanup'
+---
+
+These are a few guidelines on how to perform some cleanup on the server, for instance when storage space becomes a bit short.
+
+# Execute the basic-space-cleanup tool
+
+One may use the following command, to perform basic space cleanup (apt, journalctl, logs, ...) :
+`sudo yunohost tools basic-space-cleanup`
+
+Additional steps may be needed, to address current shortcomings : see https://github.com/YunoHost/issues/issues/2329 for instance.


### PR DESCRIPTION
The basic-space-cleanup tool isn't documented AFAIU.

Discussion started in https://github.com/YunoHost/yunohost/pull/1761#issuecomment-2220032791

@tituspijean suggests waiting for some improvements before documenting, but I think documenting won't harm even if that tool isn't perfect yet, since it is provided already, and suggested from time to time.