### PR TITLE
More explanations about protect_against_basic_auth_spoofing setting

### DIFF
--- a/pages/06.contribute/10.packaging_apps/60.advanced/30.sso_ldap_integration/sso_ldap_integration.md
+++ b/pages/06.contribute/10.packaging_apps/60.advanced/30.sso_ldap_integration/sso_ldap_integration.md
@@ -68,6 +68,19 @@ ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
 ```
 This will say to YunoHost that for this app we can safely transmit auth basic header from the client to the application.
 
+If you need to change this behavior after the application installation, you can set the option with:
+```bash
+sudo yunohost app setting <my_app> protect_against_basic_auth_spoofing -v false
+```
+Then you must regenerate the ssowat configuration with:
+```bash
+sudo yunohost app ssowatconf
+```
+And, finally, you need to reload nginx configuration with:
+```bash
+sudo systemctl reload nginx.service
+```
+
 ## Configuring SSOwat permissions for the app
 
 SSOwat permissions are configured using the 'permission' resource in your app's manifest.toml


### PR DESCRIPTION
It takes me about one day to understand why Authorization header do not reach my application behind the YunoHost nginx so I add some explanations about the protect_against_basic_auth_spoofing setting after having installed the application.

## Problem

- It takes me about one day to understand why Authorization header do not reach my application behind the YunoHost nginx

## Solution

- I add some explanations about the protect_against_basic_auth_spoofing setting after having installed the application

## PR checklist

- [x] PR finished and ready to be reviewed
