### PR TITLE
Make it clear that the Yunohost migration tool will update both the Debian system and the Yunohost version

### DIFF
--- a/pages/02.administer/15.admin_guide/55.upgrade/15.buster_bullseye/buster_bullseye_migration.fr.md
+++ b/pages/02.administer/15.admin_guide/55.upgrade/15.buster_bullseye/buster_bullseye_migration.fr.md
@@ -7,7 +7,7 @@ routes:
   default: '/buster_bullseye_migration'
 ---
 
-L'objectif cette page est de décrire le processus de migration d'une instance en YunoHost 4.4.x (tournant sous Debian Buster/10.x) vers YunoHost 11.x (tournant sous Debian Bullseye/11.x). Notez que nous avons décidé de sauter les numéros de versions de 5 à 10 pour suivre les numéros de versions de Debian.
+L'objectif cette page est de décrire le processus de migration d'une instance en YunoHost 4.4.x (tournant sous Debian Buster/10.x) vers YunoHost 11.x (tournant sous Debian Bullseye/11.x). Les outils Yunohost se chargent de la migration du système Debian ET des paquetages Yunohost. N'utilisez pas les outils de migration Debian (sauf à savoir ce que vous faites). Notez que nous avons décidé de sauter les numéros de versions de 5 à 10 pour suivre les numéros de versions de Debian.
 
 ## Notes importantes
 

--- a/pages/02.administer/15.admin_guide/55.upgrade/15.buster_bullseye/buster_bullseye_migration.md
+++ b/pages/02.administer/15.admin_guide/55.upgrade/15.buster_bullseye/buster_bullseye_migration.md
@@ -7,7 +7,7 @@ routes:
   default: '/buster_bullseye_migration'
 ---
 
-This page is dedicated to help you migrating an instance from YunoHost 4.4.x (running on Debian Buster/10.x) to YunoHost 11.x (running on Debian Bullseye/11.x). Note: we decided to skip the version numbers from 5 to 10 to follow the Debian version numbers.
+This page is dedicated to help you migrating an instance from YunoHost 4.4.x (running on Debian Buster/10.x) to YunoHost 11.x (running on Debian Bullseye/11.x). The Yunohost tools will migrate both the Debian system from Bullseye to Bookworm AND the Yunohost packages. Do not use the Debian tools for that (unless you know what you do). Note: we decided to skip the version numbers from 5 to 10 to follow the Debian version numbers.
 
 ## Important notes
 

--- a/pages/02.administer/15.admin_guide/55.upgrade/16.bullseye_bookworm/bullseye_bookworm_migration.fr.md
+++ b/pages/02.administer/15.admin_guide/55.upgrade/16.bullseye_bookworm/bullseye_bookworm_migration.fr.md
@@ -7,7 +7,7 @@ routes:
   default: '/bullseye_bookworm_migration'
 ---
 
-L'objectif cette page est de décrire le processus de migration d'une instance en YunoHost 11.x (tournant sous Debian Bullseye) vers YunoHost 12.x (tournant sous Debian Bookworm).
+L'objectif cette page est de décrire le processus de migration d'une instance en YunoHost 11.x (tournant sous Debian Bullseye) vers YunoHost 12.x (tournant sous Debian Bookworm). Les outils Yunohost se chargent de la migration du système Debian ET des paquetages Yunohost. N'utilisez pas les outils de migration Debian (sauf à savoir ce que vous faites).
 
 ## Notes importantes
 

--- a/pages/02.administer/15.admin_guide/55.upgrade/16.bullseye_bookworm/bullseye_bookworm_migration.md
+++ b/pages/02.administer/15.admin_guide/55.upgrade/16.bullseye_bookworm/bullseye_bookworm_migration.md
@@ -7,7 +7,7 @@ routes:
   default: '/bullseye_bookworm_migration'
 ---
 
-This page is dedicated to help you migrating an instance from YunoHost 11.x (running on Debian Bullseye) to YunoHost 12 (running on Debian Bookworm).
+This page is dedicated to help you migrating an instance from YunoHost 11.x (running on Debian Bullseye) to YunoHost 12 (running on Debian Bookworm). The Yunohost tools will migrate both the Debian system from Bullseye to Bookworm AND the Yunohost packages. Do not use the Debian tools for that (unless you know what you do).
 
 ## Important notes
 

--- a/pages/02.administer/15.admin_guide/55.upgrade/upgrade.fr.md
+++ b/pages/02.administer/15.admin_guide/55.upgrade/upgrade.fr.md
@@ -9,6 +9,10 @@ routes:
     - '/upgrade'
 ---
 
+## Utilisez les outils Yunohost
+
+À moins de savoir ce que vous faites, vous devriez utiliser les outils Yunohost plutôt que les outils Debian (apt, apt-get ou aptitude).
+
 ## Depuis la webadmin
 
 Dans la partie administration, choisir Mettre à jour le système. YunoHost va mettre à jour le catalogue des paquets système et le catalogue des applications, et afficher les mise à jour disponibles.

--- a/pages/02.administer/15.admin_guide/55.upgrade/upgrade.md
+++ b/pages/02.administer/15.admin_guide/55.upgrade/upgrade.md
@@ -9,6 +9,10 @@ routes:
     - '/upgrade'
 ---
 
+## Use the Yunohost tools
+
+Unless you know what you do, you should use the Yunohost tools to upgrade, not the Debian ones (apt, apt-get or aptitude).
+
 ## From the webadmin
 
 On the administraton panel, click on Upgrade the system. YunoHost will refresh the system package catalog as well as the application catalog, and display available upgrades.


### PR DESCRIPTION
## Problem

It was not clear for me that the Yunohost tools can migrate both the Debian system and the Yunohost packages. Actualy, while testing the migration, I wrongly understood an error message as "migrate the system first".

## Solution

Now the documentation insist on this, in french and english. Text added in the 3 relevant chapters.

## PR checklist

- [X] PR finished and ready to be reviewed
