### PR TITLE
Fix syntax issue in what_is_yunohost

### DIFF
--- a/docs/admin/02.what_is_yunohost/index.mdx
+++ b/docs/admin/02.what_is_yunohost/index.mdx
@@ -5,7 +5,7 @@ description: " "
 
 <img src={require('/img/icons/logo-ynh_horizontal.png').default} alt="YunoHost logo" id="ynhlogo" style={{display: "block", textAlign: "center", margin: "auto"}}/>
 
-YunoHost is an **operating system** aiming to simplify **server administration** and therefore democratize [self-hosting](/admin/self_hosting) while making sure it stays reliable, secure, ethical and lightweight. It is a copylefted libre software project maintained exclusively by volunteers. Technically, it can be seen as a distribution based on [Debian GNU/Linux](https://debian.org) and can be installed on [many kinds of hardware](/admin/install.
+YunoHost is an **operating system** aiming to simplify **server administration** and therefore democratize [self-hosting](/admin/self_hosting) while making sure it stays reliable, secure, ethical and lightweight. It is a copylefted libre software project maintained exclusively by volunteers. Technically, it can be seen as a distribution based on [Debian GNU/Linux](https://debian.org) and can be installed on [many kinds of hardware](/admin/install/install_on).
 
 ## Features
 


### PR DESCRIPTION
## Problem

- A link [in this page](https://doc.yunohost.org/admin/what_is_yunohost/) is broken

## Solution

- Fix the syntax
- Also point to `/admin/install/install_on` which is the page that used to be linked here

## PR checklist

- [x] PR finished and ready to be reviewed
