### PR TITLE
Update 20.servers.mdx

### DIFF
--- a/docs/admin/03.self_hosting/10.providers/20.servers.mdx
+++ b/docs/admin/03.self_hosting/10.providers/20.servers.mdx
@@ -11,6 +11,8 @@ import {HighlightFFDN, HighlightNonProfit, HighlightCHATONS} from '@site/src/com
 
 * [ECOWAN](https://ecowan.fr) (VPS)
 
+* [Hosterfy](https://www.hosterfy.com/en/kvm-vps-hosting) (VPS)
+
 * [Scaleway Dedibox](https://www.scaleway.com/en/dedibox/operating-systems/) (dedicated server)
 
 ## YunoHost IT outsourcing


### PR DESCRIPTION
## Problem

- To offer an even wider range of choices for users, it's beneficial to expand the list of hosting providers that offer pre-installed YunoHost.

## Solution

- I've added Hosterfy to the documentation's list of recommended hosting providers. They offer VPS plans with a YunoHost pre-installation, providing another convenient option for quick and easy server deployment.

## PR checklist

- [ ] PR finished and ready to be reviewed
