### PR TITLE
Better XMPP client list

### DIFF
--- a/docs/community/20.chat_rooms.mdx
+++ b/docs/community/20.chat_rooms.mdx
@@ -8,7 +8,7 @@ Among other communication tools, YunoHost project use chat rooms to communicate.
 You could join those chat rooms using:
 
 - a [Matrix client](https://matrix.org/ecosystem/clients/)
-- a [XMPP client](https://en.wikipedia.org/wiki/Comparison_of_instant_messaging_clients)
+- a [XMPP client](https://xmpp.org/software/)
 - an [IRC Client](https://en.wikipedia.org/wiki/Comparison_of_Internet_Relay_Chat_clients) for example [KiwiIRC](https://web.libera.chat/#yunohost) (please note that the IRC room is deprecated, prefer Matrix)
 
 Please change your username, as we got legions of `ynhuser`s.


### PR DESCRIPTION
## Problem

- the previous link listed a lot of non xmpp clients, so most of the clients were irrelevant to the user

## Solution

- the new link offers various filters to help the user to choose a client, it is also hosted on the official xmpp website

## PR checklist

- [x] PR finished and ready to be reviewed
