### PR TITLE
Explain that SSO headers are set only if the associated app permissio…

### DIFF
--- a/docs/packaging/60.advanced/30.sso_ldap_integration.mdx
+++ b/docs/packaging/60.advanced/30.sso_ldap_integration.mdx
@@ -34,7 +34,7 @@ TODO/FIXME: moar explanations? What is missing?
 
 This documentation apply to YunoHost\>=12. On YunoHost \<12 the header was a bit different but the idea was the same.
 
-Internally, SSOwat will on-the-fly inject theses different headers:
+Internally, SSOwat will on-the-fly inject theses different headers, if the `resources.main.auth_header` permission is set to true in the app's manifest:
 
 <!-- TODO: better table -->
 


### PR DESCRIPTION
…n is set

## Problem

- The documentation is incomplete regarding auth headers

## Solution

- Explain that the headers are set only if the right permission is set.

## PR checklist

- [ ] PR finished and ready to be reviewed
