### PR TITLE
Fix env variables for custom_dns_rules hook

### DIFF
--- a/docs/packaging/60.advanced/50.hooks.mdx
+++ b/docs/packaging/60.advanced/50.hooks.mdx
@@ -285,7 +285,7 @@ This hook is run at the end of the command `yunohost domain dns suggest` or equi
 
 Thanks to This hook you can customize
 
-##### Environment variables
+#### Environment variables
 
 - `base_domain`: the top-level part of the domain
 - `suffix`: the subdomain part of the domain


### PR DESCRIPTION
Missing information about environmental variables for the custom_dns_rules hook. (https://github.com/YunoHost/yunohost/blob/5ae3c56794c89bff00346f935cb5abc18ff95467/src/dns.py#L257)

## PR checklist

- [X] PR finished and ready to be reviewed
