### PR TITLE
Fix `packages` property's example syntax

### DIFF
--- a/docs/dev/50.packaging/15.resources.mdx
+++ b/docs/dev/50.packaging/15.resources.mdx
@@ -14,17 +14,17 @@ Create a virtual package in apt, depending on the list of specified packages tha
 
 ```toml
 [resources.apt]
-packages = ["nyancat", "lolcat", "sl"]
+packages = "nyancat, lolcat, sl"
 
 # (this part is optional and corresponds to the legacy ynh_install_extra_app_dependencies helper)
 extras.yarn.repo = "deb https://dl.yarnpkg.com/debian/ stable main"
 extras.yarn.key = "https://dl.yarnpkg.com/debian/pubkey.gpg"
-extras.yarn.packages = ["yarn"]
+extras.yarn.packages = "yarn"
 ```
 
 ### Properties
 
-- `packages`: List of packages to be installed via `apt`
+- `packages`: List of packages to be installed via `apt` (comma-separated string)
 - `packages_from_raw_bash`: A multi-line bash snippet (using triple quotes as open/close) which should echo additional packages to be installed. Meant to be used for packages to be conditionally installed depending on architecture, debian version, install questions, or other logic.
 - `extras`: A dict of (repo, key, packages) corresponding to "extra" repositories to fetch dependencies from
 


### PR DESCRIPTION
So far 'packages' property in `manifest.toml` is meant to be formatted as a comma-separated string. Cf. https://github.com/search?q=org%3AYunoHost-Apps+path%3Amanifest.toml+resources.apt&type=code