### PR TITLE
Update Magyar Telekom ISP provider details in documentation

### DIFF
--- a/docs/admin/05.get_started/10.providers/10.isp.mdx
+++ b/docs/admin/05.get_started/10.providers/10.isp.mdx
@@ -119,10 +119,10 @@ Pour une liste plus complète et précise, référez-vous à la très bonne docu
 </TabItem>
 <TabItem value="hun" label="Hungary">
 
-| Service provider                      | Port 25 openable   | [Hairpinning](http://en.wikipedia.org/wiki/Hairpinning) | Customizable reverse DNS | Fixed IP   |
-| ------------------------------------- | ------------------ | ------------------------------------------------------- | ------------------------ | ---------- |
-| DIGI Távközlési és Szolgáltató Kft.   | No. Business only. | No                                                      | No. Business only | No. Business only |
-| Telekom Magyarország                  | No                 | No                                                      | No                | No                |
+| Service provider                      | Port 25 openable   | [Hairpinning](http://en.wikipedia.org/wiki/Hairpinning) | Customizable reverse DNS | Fixed IP       |
+| ------------------------------------- | ------------------ | ------------------------------------------------------- | ------------------------ | -------------- |
+| DIGI Távközlési és Szolgáltató Kft.   | No. Business only. | No                                                      | No. Business only | No. Business only     |
+| Telekom Magyarország                  | No                 | No                                                      | No                | Yes, with bridge mode |
 
 :::tip
 DIGI allows non-business users to subscribe to their business plan, for roughly the same price as the regular plan. Fix IP is an additional subscription for business plan users.


### PR DESCRIPTION
## Problem

- *The fixed IP is available for customers of Magyar Telekom when the user enable the bridge mode on ISP modem*
