### PR TITLE
Removed redundant toml invocation in app manifest documentation

### DIFF
--- a/docs/dev/50.packaging/10.manifest.mdx
+++ b/docs/dev/50.packaging/10.manifest.mdx
@@ -164,7 +164,6 @@ The resource section corresponds to recurring app needs that are to be provision
 
 ```toml
 [resources]
-```toml
     [resources.sources.main]
     url = "https://some.domain/url/where/to/download/the/app/sources.tar.gz"
     sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"


### PR DESCRIPTION
## Problem

- Redundant toml section declaration in the yunhost app manifest documentation. Seems obvious, but might confuse new/inexperienced users.

## Solution

- Remove extra toml declaration.

## PR checklist

- [x] PR finished and ready to be reviewed
