### PR TITLE
docs: "admin" user deprecated, mention the "admin" group instead

### DIFF
--- a/docs/admin/50.troubleshooting/15.noaccess.mdx
+++ b/docs/admin/50.troubleshooting/15.noaccess.mdx
@@ -42,9 +42,9 @@ You can check that the DNS records are correct by comparing the results given by
 
 ## You have access via SSH but not via the webadmin, or inversely
 
-### You are trying to log in with SSH as `root` instead of a user from the `admin` group
+### You are trying to log in with SSH as `root` instead of a user from the `admins` group
 
-By default, SSH connection has to be made as a user in the `admin` group. It possible to log into the server as `root` *only from the local network of the server*. If your server is a VPS, the web console or VNC provided by VPS providers may work.
+By default, SSH connection has to be made as a user in the `admins` group. It possible to log into the server as `root` *only from the local network of the server*. If your server is a VPS, the web console or VNC provided by VPS providers may work.
 
 If you are running `yunohost` commands in the CLI as an administrator of your server, you have to call them with `sudo` before (for example `sudo yunohost user list`). You can also become `root` by running `sudo su`.
 

--- a/docs/admin/50.troubleshooting/15.noaccess.mdx
+++ b/docs/admin/50.troubleshooting/15.noaccess.mdx
@@ -42,11 +42,11 @@ You can check that the DNS records are correct by comparing the results given by
 
 ## You have access via SSH but not via the webadmin, or inversely
 
-### You are trying to log in with SSH as `root` instead of `admin` user
+### You are trying to log in with SSH as `root` instead of a user from the `admin` group
 
-By default, SSH connection has to be made as `admin`. It possible to log into the server as `root` *only from the local network of the server*. If your server is a VPS, the web console or VNC provided by VPS providers may work.
+By default, SSH connection has to be made as a user in the `admin` group. It possible to log into the server as `root` *only from the local network of the server*. If your server is a VPS, the web console or VNC provided by VPS providers may work.
 
-If you are running `yunohost` commands in the CLI as `admin`, you have to call them with `sudo` before (for example `sudo yunohost user list`). You can also become `root` by running `sudo su`.
+If you are running `yunohost` commands in the CLI as an administrator of your server, you have to call them with `sudo` before (for example `sudo yunohost user list`). You can also become `root` by running `sudo su`.
 
 ### You have been temporarily banned
 


### PR DESCRIPTION
## Problem

The "admin" user is now deprecated in YunoHost, and [this documentation page](https://doc.yunohost.org/en/admin/troubleshooting/noaccess#you-are-trying-to-log-in-with-ssh-as-root-instead-of-admin-user) is still mentioning the `admin` user.

## Solution

I fixed this by instead mentioning users in the `admin` group, instead of mentioning the deprecated `admin` user.

## PR checklist

- [x] PR finished and ready to be reviewed
